### PR TITLE
Updating version to 1.1.0-alpha

### DIFF
--- a/src/Tests.Marvin/IdentifiableSecretsTests.cs
+++ b/src/Tests.Marvin/IdentifiableSecretsTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Security.Utilities
             var isValid = IdentifiableSecrets.ValidateKey(newSecret, seed, Signature);
             Assert.IsFalse(isValid);
 
-            newSecret = secret.Remove(secret.Length - 2, 1).Insert(secret.Length - 2, "+");
+            newSecret = secret.Remove(secret.Length - 3, 2).Insert(secret.Length - 3, "++");
             isValid = IdentifiableSecrets.ValidateKey(newSecret, seed, Signature);
             Assert.IsFalse(isValid);
         }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0-beta.{height}",
+  "version": "1.1.0-alpha.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
Changing version to 1.1.0-alpha since we are going to release the version v1.0.0 from release/v1.0.0.
This will enable us to:
- always have the release/v1.0.0 branch to track
- easy to hotfix (we can start a branch from release/v1.0.0, make the fix, and ship)