### PR TITLE
Adding Custom Alphabet Encoder Class

### DIFF
--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Security.Utilities
         /// <returns>
         /// The unsigned integer encoded using the character set with which this class was instantiated.
         /// </returns>
-        public string Encode (uint data)
+        public string Encode(uint data)
         {
             sb ??= new StringBuilder();
             sb.Clear();

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Security.Utilities
 
                 if (Char.IsWhiteSpace(alphabet[i]) || Char.IsSurrogate(alphabet[i]) || (int)alphabet[i] > 127)
                 {
-                    throw new ArgumentException(nameof(customAlphabet), $"Forbidden character type detected in the alphabet: alphabet[i].");
+                    throw new ArgumentException(nameof(customAlphabet), $"Forbidden character type detected in the alphabet: {alphabet[i]}.");
                 }
 
                 charToValueMap[alphabet[i]] = (uint)i;

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -16,10 +16,11 @@ namespace Microsoft.Security.Utilities
         internal const string DefaultBase62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
         [ThreadStatic]
-        private static StringBuilder sb;
-        private static string alphabet;
-        private static uint baseEncoding;
-        private static Dictionary<char, uint> charToValueMap;
+        private static StringBuilder s_sb;
+
+        private string alphabet;
+        private uint baseEncoding;
+        private Dictionary<char, uint> charToValueMap;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomAlphabetEncoder"/> class.
@@ -30,8 +31,8 @@ namespace Microsoft.Security.Utilities
             alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
             baseEncoding = (uint)alphabet.Length;
 
-            charToValueMap = new Dictionary<char,uint>();
-            for (int i = 0; i < alphabet.Length; i++)
+            charToValueMap = new Dictionary<char, uint>();
+            for (int i = 0; i < baseEncoding; i++)
             {
                 // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
                 if(charToValueMap.ContainsKey(alphabet[i]))
@@ -44,38 +45,6 @@ namespace Microsoft.Security.Utilities
         }
 
         /// <summary>
-        /// Encode a byte array in a given character set.
-        /// </summary>
-        /// <param name="data">The byte array to encode. Must be 4 bytes or less.</param>
-        /// <returns>
-        /// The byte array encoded using the character set with which this class was instantiated.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown if 'data' is null.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if the length of the data array is greater than 4.</exception>
-        public string Encode(byte[] data)
-        {
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            // input 'data' is restricted to the range uint.MinValue to uint.MaxValue
-            if (data.Length < 0 || data.Length > 4)
-            {
-                throw new ArgumentOutOfRangeException(nameof(data));
-            }
-
-            if (data.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            uint convertedInput = BitConverter.ToUInt32(data, 0);
-
-            return Encode(convertedInput);
-        }
-
-        /// <summary>
         /// Encode an unsigned integer (a checksum) in a given character set.
         /// </summary>
         /// <param name="data">The unsigned integer to encode.</param>
@@ -84,16 +53,16 @@ namespace Microsoft.Security.Utilities
         /// </returns>
         public string Encode(uint data)
         {
-            sb ??= new StringBuilder();
-            sb.Clear();
+            s_sb ??= new StringBuilder();
+            s_sb.Clear();
 
             while (data > 0)
             {
-                sb.Append(alphabet[(int)(data % baseEncoding)]);
+                s_sb.Append(alphabet[(int)(data % baseEncoding)]);
                 data /= baseEncoding;
             }
 
-            return new string(sb.ToString().Reverse().ToArray());
+            return new string(s_sb.ToString().Reverse().ToArray());
         }
 
         /// <summary>

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -39,14 +39,14 @@ namespace Microsoft.Security.Utilities
             for (int i = 0; i < alphabet.Length; i++)
             {
                 // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
-                if(charToValueMap.ContainsKey(alphabet[i]))
+                if (charToValueMap.ContainsKey(alphabet[i]))
                 {
                     throw new ArgumentException(nameof(customAlphabet), "Duplicate value detected in the alphabet.");
                 }
 
                 if (Char.IsWhiteSpace(alphabet[i]) || Char.IsSurrogate(alphabet[i]) || (int)alphabet[i] > 127)
                 {
-                    throw new ArgumentException(nameof(customAlphabet), String.Format("Forbidden character type detected in the alphabet: {0}.", alphabet[i]));
+                    throw new ArgumentException(nameof(customAlphabet), $"Forbidden character type detected in the alphabet: alphabet[i].");
                 }
 
                 charToValueMap[alphabet[i]] = (uint)i;
@@ -90,14 +90,16 @@ namespace Microsoft.Security.Utilities
             }
 
             uint decodedValue = 0;
+            uint alphabetLength = (uint)alphabet.Length;
 
             foreach (char c in encodedValue)
             {
-                if(!charToValueMap.ContainsKey(c))
+                if (!charToValueMap.ContainsKey(c))
                 {
                     throw new ArgumentException(nameof(encodedValue), "Alphabet does not contain all characters in input");
                 }
-                decodedValue *= (uint)alphabet.Length;
+
+                decodedValue *= alphabetLength;
                 decodedValue += charToValueMap[c];
             }
 

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Security.Utilities
         {
             alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
 
-            if(alphabet.Length < 2)
+            if (alphabet.Length < 2)
             {
                 throw new ArgumentException(nameof(customAlphabet), "Alphabet must be at least 2 characters.");
             }

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Security.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Custom encoder class.
+    /// </summary>
+    public class CustomAlphabetEncoder
+    {
+        internal const string DefaultBase62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        [ThreadStatic]
+        private static StringBuilder sb;
+        private static string alphabet;
+        private static uint baseEncoding;
+        private static Dictionary<char, uint> charToValueMap;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomAlphabetEncoder"/> class.
+        /// </summary>
+        /// <param name="customAlphabet">The alphabet to be used for all encoding/decoding operations.</param>
+        public CustomAlphabetEncoder(string customAlphabet = DefaultBase62Alphabet)
+        {
+            alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
+            baseEncoding = (uint)alphabet.Length;
+
+            charToValueMap = new Dictionary<char,uint>();
+            for (int i = 0; i < alphabet.Length; i++)
+            {
+                charToValueMap[alphabet[i]] = (uint)i;
+            }
+        }
+
+        /// <summary>
+        /// Encode a byte array in a given character set.
+        /// </summary>
+        /// <param name="data">The byte array to encode. Must be 4 bytes or less.</param>
+        /// <returns>
+        /// The byte array encoded using the character set with which this class was instantiated.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown if 'data' is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the length of the data array is greater than 4.</exception>
+        public string Encode(byte[] data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            // input 'data' is restricted to the range uint.MinValue to uint.MaxValue
+            if (data.Length < 0 || data.Length > 4)
+            {
+                throw new ArgumentOutOfRangeException(nameof(data));
+            }
+
+            if (data.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            uint convertedInput = BitConverter.ToUInt32(data, 0);
+
+            return Encode(convertedInput);
+        }
+
+        /// <summary>
+        /// Encode an unsigned integer (a checksum) in a given character set.
+        /// </summary>
+        /// <param name="data">The unsigned integer to encode.</param>
+        /// <returns>
+        /// The unsigned integer encoded using the character set with which this class was instantiated.
+        /// </returns>
+        public string Encode (uint data)
+        {
+            sb ??= new StringBuilder();
+            sb.Clear();
+
+            while (data > 0)
+            {
+                sb.Append(alphabet[(int)(data % baseEncoding)]);
+                data /= baseEncoding;
+            }
+
+            return new string(sb.ToString().Reverse().ToArray());
+        }
+
+        /// <summary>
+        /// Decode a byte array from a given character set.
+        /// </summary>
+        /// <param name="encodedValue">The encoded byte array to decode.</param>
+        /// <returns>
+        /// The byte array encoded using the character set wit which this class was instantiated.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="encodedValue"/> is null.</exception>
+        public byte[] Decode(string encodedValue)
+        {
+            if (encodedValue == null)
+            {
+                throw new ArgumentNullException(nameof(encodedValue));
+            }
+
+            uint decodedValue = 0;
+
+            foreach (char c in encodedValue)
+            {
+                decodedValue *= baseEncoding;
+                decodedValue += charToValueMap[c];
+            }
+
+            return BitConverter.GetBytes(decodedValue);
+        }
+    }
+}

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Security.Utilities
         private static StringBuilder s_sb;
 
         private string alphabet;
-        private uint alphabetLength;
         private Dictionary<char, uint> charToValueMap;
 
         /// <summary>
@@ -30,15 +29,14 @@ namespace Microsoft.Security.Utilities
         public CustomAlphabetEncoder(string customAlphabet = DefaultBase62Alphabet)
         {
             alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
-            alphabetLength = (uint)alphabet.Length;
 
-            if(alphabetLength < 2)
+            if(alphabet.Length < 2)
             {
                 throw new ArgumentException(nameof(customAlphabet), "Alphabet must be at least 2 characters.");
             }
 
             charToValueMap = new Dictionary<char, uint>();
-            for (int i = 0; i < alphabetLength; i++)
+            for (int i = 0; i < alphabet.Length; i++)
             {
                 // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
                 if(charToValueMap.ContainsKey(alphabet[i]))
@@ -69,8 +67,8 @@ namespace Microsoft.Security.Utilities
 
             while (data > 0)
             {
-                s_sb.Append(alphabet[(int)(data % alphabetLength)]);
-                data /= alphabetLength;
+                s_sb.Append(alphabet[(int)(data % (uint)alphabet.Length)]);
+                data /= (uint)alphabet.Length;
             }
 
             return new string(s_sb.ToString().Reverse().ToArray());
@@ -99,7 +97,7 @@ namespace Microsoft.Security.Utilities
                 {
                     throw new ArgumentException(nameof(encodedValue), "Alphabet does not contain all characters in input");
                 }
-                decodedValue *= alphabetLength;
+                decodedValue *= (uint)alphabet.Length;
                 decodedValue += charToValueMap[c];
             }
 

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
 namespace Microsoft.Security.Utilities
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-
     /// <summary>
     /// Custom encoder class.
     /// </summary>
@@ -33,6 +33,12 @@ namespace Microsoft.Security.Utilities
             charToValueMap = new Dictionary<char,uint>();
             for (int i = 0; i < alphabet.Length; i++)
             {
+                // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
+                if(charToValueMap.ContainsKey(alphabet[i]))
+                {
+                    throw new ArgumentException(nameof(customAlphabet));
+                }
+
                 charToValueMap[alphabet[i]] = (uint)i;
             }
         }

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Security.Utilities
         private static StringBuilder s_sb;
 
         private string alphabet;
-        private uint baseEncoding;
+        private uint alphabetLength;
         private Dictionary<char, uint> charToValueMap;
 
         /// <summary>
@@ -30,15 +30,15 @@ namespace Microsoft.Security.Utilities
         public CustomAlphabetEncoder(string customAlphabet = DefaultBase62Alphabet)
         {
             alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
-            baseEncoding = (uint)alphabet.Length;
+            alphabetLength = (uint)alphabet.Length;
 
-            if(baseEncoding < 2)
+            if(alphabetLength < 2)
             {
                 throw new ArgumentException(nameof(customAlphabet), "Alphabet must be at least 2 characters.");
             }
 
             charToValueMap = new Dictionary<char, uint>();
-            for (int i = 0; i < baseEncoding; i++)
+            for (int i = 0; i < alphabetLength; i++)
             {
                 // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
                 if(charToValueMap.ContainsKey(alphabet[i]))
@@ -69,8 +69,8 @@ namespace Microsoft.Security.Utilities
 
             while (data > 0)
             {
-                s_sb.Append(alphabet[(int)(data % baseEncoding)]);
-                data /= baseEncoding;
+                s_sb.Append(alphabet[(int)(data % alphabetLength)]);
+                data /= alphabetLength;
             }
 
             return new string(s_sb.ToString().Reverse().ToArray());
@@ -99,7 +99,7 @@ namespace Microsoft.Security.Utilities
                 {
                     throw new ArgumentException(nameof(encodedValue), "Alphabet does not contain all characters in input");
                 }
-                decodedValue *= baseEncoding;
+                decodedValue *= alphabetLength;
                 decodedValue += charToValueMap[c];
             }
 

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Security.Utilities
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomAlphabetEncoder"/> class.
         /// </summary>
-        /// <param name="customAlphabet">The alphabet to be used for all encoding/decoding operations.</param>
+        /// <param name="customAlphabet">The alphabet to be used for all encoding/decoding operations. Must consist of nonwhitespace ASCII letters, numbers, and/or punctuation.</param>
         /// <exception cref="ArgumentException">customAlphabet contains a duplicate or forbidden character.</exception>
         public CustomAlphabetEncoder(string customAlphabet = DefaultBase62Alphabet)
         {
@@ -46,7 +46,7 @@ namespace Microsoft.Security.Utilities
 
                 if (Char.IsWhiteSpace(alphabet[i]) || Char.IsSurrogate(alphabet[i]) || (int)alphabet[i] > 127)
                 {
-                    throw new ArgumentException(nameof(customAlphabet), "Forbidden character type detected in the alphabet.");
+                    throw new ArgumentException(nameof(customAlphabet), String.Format("Forbidden character type detected in the alphabet: {0}.", alphabet[i]));
                 }
 
                 charToValueMap[alphabet[i]] = (uint)i;

--- a/src/Marvin/CustomAlphabetEncoder.cs
+++ b/src/Marvin/CustomAlphabetEncoder.cs
@@ -26,10 +26,16 @@ namespace Microsoft.Security.Utilities
         /// Initializes a new instance of the <see cref="CustomAlphabetEncoder"/> class.
         /// </summary>
         /// <param name="customAlphabet">The alphabet to be used for all encoding/decoding operations.</param>
+        /// <exception cref="ArgumentException">customAlphabet contains a duplicate or forbidden character.</exception>
         public CustomAlphabetEncoder(string customAlphabet = DefaultBase62Alphabet)
         {
             alphabet = string.IsNullOrWhiteSpace(customAlphabet) ? DefaultBase62Alphabet : customAlphabet;
             baseEncoding = (uint)alphabet.Length;
+
+            if(baseEncoding < 2)
+            {
+                throw new ArgumentException(nameof(customAlphabet), "Alphabet must be at least 2 characters.");
+            }
 
             charToValueMap = new Dictionary<char, uint>();
             for (int i = 0; i < baseEncoding; i++)
@@ -37,7 +43,12 @@ namespace Microsoft.Security.Utilities
                 // Repeated values in the custom alphabet will cause unreliable encoding/decoding.
                 if(charToValueMap.ContainsKey(alphabet[i]))
                 {
-                    throw new ArgumentException(nameof(customAlphabet));
+                    throw new ArgumentException(nameof(customAlphabet), "Duplicate value detected in the alphabet.");
+                }
+
+                if (Char.IsWhiteSpace(alphabet[i]) || Char.IsSurrogate(alphabet[i]) || (int)alphabet[i] > 127)
+                {
+                    throw new ArgumentException(nameof(customAlphabet), "Forbidden character type detected in the alphabet.");
                 }
 
                 charToValueMap[alphabet[i]] = (uint)i;
@@ -84,6 +95,10 @@ namespace Microsoft.Security.Utilities
 
             foreach (char c in encodedValue)
             {
+                if(!charToValueMap.ContainsKey(c))
+                {
+                    throw new ArgumentException(nameof(encodedValue), "Alphabet does not contain all characters in input");
+                }
                 decodedValue *= baseEncoding;
                 decodedValue += charToValueMap[c];
             }

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -109,43 +109,43 @@ namespace Microsoft.Security.Utilities
             {
                 new {
                     Alphabet = "a",
-                    ExpectedException = new ArgumentException("customAlphabet", "Alphabet must be at least 2 characters.")
+                    ExpectedMessage = "Alphabet must be at least 2 characters."
                 },
                 new {
                     Alphabet = "aaa",
-                    ExpectedException = new ArgumentException("customAlphabet", "Duplicate value detected in the alphabet.")
+                    ExpectedMessage = "Duplicate value detected in the alphabet."
                 },
                 new {
                     Alphabet = GenerateAsciiString(),
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "abc\uD800",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "abc\uDC00",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = GenerateAsciiString(130,132),
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "₼abc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "ﺀabc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "∞abc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
                 new {
                     Alphabet = "µabc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
+                    ExpectedMessage = "Forbidden character type detected in the alphabet"
                 },
             };
 
@@ -153,7 +153,7 @@ namespace Microsoft.Security.Utilities
             {
                 Action action = () => new CustomAlphabetEncoder(testCase.Alphabet);
 
-                action.Should().Throw<ArgumentException>().Where(e => e.Message.StartsWith(testCase.ExpectedException.Message));
+                action.Should().Throw<ArgumentException>().Where(e => e.Message.Contains(testCase.ExpectedMessage));
             }
         }
 

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Security.Utilities
         {
             var sb = new StringBuilder();
 
-            for(int i = low; i < high; i++)
+            for (int i = low; i < high; i++)
             {
                 sb.Append((char)i);
             }

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Security.Utilities
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CustomAlphabetEncoderTests
+    {
+        /// <summary>
+        /// Test Encode Uint generates expected results given a provided or default alphabet.
+        /// </summary>
+        /// <param name="expected">The expected result of Encode for the given parameters.</param>
+        /// <param name="input">The input to be encoded.</param>
+        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
+        [TestMethod]
+        [DataRow("399Wq7", 2883656711, null)]
+        [DataRow("", null, null)]
+        public void CustomAlphabetEncoder_EncodeUintWithDefaultAlphabet(string expected, uint input, string alphabet)
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            string actualEncoded = testEncoder.Encode(input);
+            Assert.AreEqual(expected, actualEncoded);
+
+            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+            uint actualDecodedUint = BitConverter.ToUInt32(actualDecoded, 0);
+
+            Assert.AreEqual(input, actualDecodedUint);
+        }
+
+        /// <summary>
+        /// Test encoding a byte array produces and then decoding the byte array produces the expected results.
+        /// </summary>
+        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
+        /// <param name="input">Input used to generate a byte array for encoding/decoding.</param>
+        [TestMethod]
+        [DataRow("ABC123", (uint)123456)]
+        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (uint)123456)]
+        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", UInt32.MinValue)]
+        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", UInt32.MaxValue)]
+        public void CustomAlphabetEncoder_EncodeByteArrayWithCustomAlphabet(string alphabet, uint input)
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            byte[] data = BitConverter.GetBytes(input);
+
+            string actualEncoded = testEncoder.Encode(data);
+            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+
+            AssertByteArraysAreEqual(data, actualDecoded);
+        }
+
+        /// <summary>
+        /// Test that correct exception is thrown if byte array is out of the allowed uint range.
+        /// </summary>
+        /// <param name="alphabet">The alphabet with which to instantiate the CustomAlphabetEncoder.</param>
+        /// <param name="testInput">Example input which should throw an exception.</param>
+        [TestMethod]
+        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (long)UInt32.MinValue - 1)]
+        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (long)UInt32.MaxValue + 1)]
+        public void CustomAlphabetEncoder_ShouldValidateUintOnEncodeByteArray(string alphabet, long testInput)
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            byte[] data = BitConverter.GetBytes(testInput);
+
+            Action action = () => testEncoder.Encode(data);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(action);
+        }
+
+        /// <summary>
+        /// Compare values of a byte array instead of references of a byte array.
+        /// </summary>
+        /// <param name="expected">The expected byte array content.</param>
+        /// <param name="actual">The byte array content being tested.</param>
+        public void AssertByteArraysAreEqual(byte[] expected, byte[] actual)
+        {
+            Assert.AreEqual(expected.Length, actual.Length);
+            
+            for(int i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i], actual[i]);
+            }
+        }
+    }
+}

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace Microsoft.Security.Utilities
 {
-    using System;
-    using FluentAssertions;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class CustomAlphabetEncoderTests
@@ -49,7 +50,44 @@ namespace Microsoft.Security.Utilities
             string actualEncoded = testEncoder.Encode(data);
             byte[] actualDecoded = testEncoder.Decode(actualEncoded);
 
-            AssertByteArraysAreEqual(data, actualDecoded);
+            actualDecoded.Should().BeEquivalentTo(data);
+        }
+
+        /// <summary>
+        /// Test encoding a byte array produces and then decoding the byte array produces the expected results.
+        /// </summary>
+        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
+        /// <param name="input">Input used to generate a byte array for encoding/decoding.</param>
+        [TestMethod]
+        [DataRow("abc", "abc")]
+        [DataRow("abc", "abcdef")]
+        [DataRow(".!@#$%&*", "abcdef")]
+        public void CustomAlphabetEncoder_EncodeByteArrayFromStringWithCustomAlphabet(string alphabet, string input)
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            int data = input.GetHashCode();
+            byte[] expected = BitConverter.GetBytes(data);
+
+            string actualEncoded = testEncoder.Encode((uint)data);
+            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+
+            actualDecoded.Should().BeEquivalentTo(expected);
+        }
+
+        /// <summary>
+        /// Test to ensure encode and decode are not impacted by duplicate characters in a custom alphabet.
+        /// </summary>
+        /// <param name="alphabet">Custom alphabet test case with duplicate characters.</param>
+        [TestMethod]
+        [DataRow("abcabc")]
+        [DataRow("abbc")]
+        [DataRow("11 2 3")]
+        [DataRow("1 2 3 a b c")]
+        public void CustomAlphabetEncoder_ShouldThrowInvalidArgumentExceptionIfCharacterRepeats(string alphabet)
+        {
+            Action action = () => new CustomAlphabetEncoder(alphabet);
+
+            action.Should().Throw<ArgumentException>();
         }
 
         /// <summary>
@@ -93,21 +131,6 @@ namespace Microsoft.Security.Utilities
 
             Action decodeAction = () => testEncoder.Decode(data);
             decodeAction.Should().Throw<ArgumentNullException>();
-        }
-
-        /// <summary>
-        /// Compare values of a byte array instead of references of a byte array.
-        /// </summary>
-        /// <param name="expected">The expected byte array content.</param>
-        /// <param name="actual">The byte array content being tested.</param>
-        private void AssertByteArraysAreEqual(byte[] expected, byte[] actual)
-        {
-            actual.Should().BeEquivalentTo(expected);
-            
-            for(int i = 0; i < expected.Length; i++)
-            {
-                actual[i].Should().Be(expected[i]);
-            }
         }
     }
 }

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Security.Utilities
 {
     using System;
+    using FluentAssertions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -65,7 +66,33 @@ namespace Microsoft.Security.Utilities
             byte[] data = BitConverter.GetBytes(testInput);
 
             Action action = () => testEncoder.Encode(data);
-            Assert.ThrowsException<ArgumentOutOfRangeException>(action);
+            action.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        /// <summary>
+        /// Test that the correct exception is thrown if byte array input is null on encode.
+        /// </summary>
+        [TestMethod]
+        public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnEncodeByteArray()
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder("abc");
+            byte[] data = null;
+
+            Action encodeAction = () => testEncoder.Encode(data);
+            encodeAction.Should().Throw<ArgumentNullException>();
+        }
+
+        /// <summary>
+        /// Test that the correct exception is thrown if string input is null on decode.
+        /// </summary>
+        [TestMethod]
+        public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnDecodeByteArray()
+        {
+            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder("abc");
+            string data = null;
+
+            Action decodeAction = () => testEncoder.Decode(data);
+            decodeAction.Should().Throw<ArgumentNullException>();
         }
 
         /// <summary>
@@ -73,13 +100,13 @@ namespace Microsoft.Security.Utilities
         /// </summary>
         /// <param name="expected">The expected byte array content.</param>
         /// <param name="actual">The byte array content being tested.</param>
-        public void AssertByteArraysAreEqual(byte[] expected, byte[] actual)
+        private void AssertByteArraysAreEqual(byte[] expected, byte[] actual)
         {
-            Assert.AreEqual(expected.Length, actual.Length);
+            actual.Should().BeEquivalentTo(expected);
             
             for(int i = 0; i < expected.Length; i++)
             {
-                Assert.AreEqual(expected[i], actual[i]);
+                actual[i].Should().Be(expected[i]);
             }
         }
     }

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -117,35 +117,35 @@ namespace Microsoft.Security.Utilities
                 },
                 new {
                     Alphabet = GenerateAsciiString(),
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "abc\uD800",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "abc\uDC00",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = GenerateAsciiString(130,132),
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "₼abc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "ﺀabc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "∞abc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
                 new {
                     Alphabet = "µabc",
-                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet")
                 },
             };
 
@@ -153,7 +153,7 @@ namespace Microsoft.Security.Utilities
             {
                 Action action = () => new CustomAlphabetEncoder(testCase.Alphabet);
 
-                action.Should().Throw<ArgumentException>().WithMessage(testCase.ExpectedException.Message);
+                action.Should().Throw<ArgumentException>().Where(e => e.Message.StartsWith(testCase.ExpectedException.Message));
             }
         }
 

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -195,21 +195,15 @@ namespace Microsoft.Security.Utilities
 
         private IEnumerable<string> GenerateValidAlphabetTestCases()
         {
-            Random random = new Random();
-
             var output = new List<string>
             {
                 String.Empty,
-                "ab",
             };
 
             // generate a sample of random test alphabets
-            for (int i = 0; i < 10; i++)
+            for (int i = 2; i < 94; i++)
             {
-                int low = random.Next(33, 120);
-                int high = random.Next(low+1, 127);
-
-                output.Add(GenerateAsciiString(low, high));
+                output.Add(GenerateAsciiString(33, (33 + i)));
             }
 
             return output;

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -11,18 +11,12 @@ namespace Microsoft.Security.Utilities
     [TestClass]
     public class CustomAlphabetEncoderTests
     {
-        /// <summary>
-        /// Test Encode Uint generates expected results given a provided or default alphabet.
-        /// </summary>
-        /// <param name="expected">The expected result of Encode for the given parameters.</param>
-        /// <param name="input">The input to be encoded.</param>
-        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
         [TestMethod]
         [DataRow("399Wq7", 2883656711, null)]
         [DataRow("", null, null)]
         public void CustomAlphabetEncoder_EncodeUintWithDefaultAlphabet(string expected, uint input, string alphabet)
         {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            var testEncoder = new CustomAlphabetEncoder(alphabet);
             string actualEncoded = testEncoder.Encode(input);
             Assert.AreEqual(expected, actualEncoded);
 
@@ -32,11 +26,6 @@ namespace Microsoft.Security.Utilities
             Assert.AreEqual(input, actualDecodedUint);
         }
 
-        /// <summary>
-        /// Test encoding a byte array produces and then decoding the byte array produces the expected results.
-        /// </summary>
-        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
-        /// <param name="input">Input used to generate a byte array for encoding/decoding.</param>
         [TestMethod]
         [DataRow("ABC123", (uint)123456)]
         [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (uint)123456)]
@@ -44,27 +33,22 @@ namespace Microsoft.Security.Utilities
         [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", UInt32.MaxValue)]
         public void CustomAlphabetEncoder_EncodeByteArrayWithCustomAlphabet(string alphabet, uint input)
         {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
-            byte[] data = BitConverter.GetBytes(input);
+            var testEncoder = new CustomAlphabetEncoder(alphabet);
+            byte[] expectedDecoded = BitConverter.GetBytes(input);
 
-            string actualEncoded = testEncoder.Encode(data);
+            string actualEncoded = testEncoder.Encode(input);
             byte[] actualDecoded = testEncoder.Decode(actualEncoded);
 
-            actualDecoded.Should().BeEquivalentTo(data);
+            actualDecoded.Should().BeEquivalentTo(expectedDecoded);
         }
 
-        /// <summary>
-        /// Test encoding a byte array produces and then decoding the byte array produces the expected results.
-        /// </summary>
-        /// <param name="alphabet">The custom alphabet to use for encoding.</param>
-        /// <param name="input">Input used to generate a byte array for encoding/decoding.</param>
         [TestMethod]
         [DataRow("abc", "abc")]
         [DataRow("abc", "abcdef")]
         [DataRow(".!@#$%&*", "abcdef")]
         public void CustomAlphabetEncoder_EncodeByteArrayFromStringWithCustomAlphabet(string alphabet, string input)
         {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
+            var testEncoder = new CustomAlphabetEncoder(alphabet);
             int data = input.GetHashCode();
             byte[] expected = BitConverter.GetBytes(data);
 
@@ -74,10 +58,6 @@ namespace Microsoft.Security.Utilities
             actualDecoded.Should().BeEquivalentTo(expected);
         }
 
-        /// <summary>
-        /// Test to ensure encode and decode are not impacted by duplicate characters in a custom alphabet.
-        /// </summary>
-        /// <param name="alphabet">Custom alphabet test case with duplicate characters.</param>
         [TestMethod]
         [DataRow("abcabc")]
         [DataRow("abbc")]
@@ -90,47 +70,29 @@ namespace Microsoft.Security.Utilities
             action.Should().Throw<ArgumentException>();
         }
 
-        /// <summary>
-        /// Test that correct exception is thrown if byte array is out of the allowed uint range.
-        /// </summary>
-        /// <param name="alphabet">The alphabet with which to instantiate the CustomAlphabetEncoder.</param>
-        /// <param name="testInput">Example input which should throw an exception.</param>
-        [TestMethod]
-        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (long)UInt32.MinValue - 1)]
-        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (long)UInt32.MaxValue + 1)]
-        public void CustomAlphabetEncoder_ShouldValidateUintOnEncodeByteArray(string alphabet, long testInput)
-        {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder(alphabet);
-            byte[] data = BitConverter.GetBytes(testInput);
-
-            Action action = () => testEncoder.Encode(data);
-            action.Should().Throw<ArgumentOutOfRangeException>();
-        }
-
-        /// <summary>
-        /// Test that the correct exception is thrown if byte array input is null on encode.
-        /// </summary>
-        [TestMethod]
-        public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnEncodeByteArray()
-        {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder("abc");
-            byte[] data = null;
-
-            Action encodeAction = () => testEncoder.Encode(data);
-            encodeAction.Should().Throw<ArgumentNullException>();
-        }
-
-        /// <summary>
-        /// Test that the correct exception is thrown if string input is null on decode.
-        /// </summary>
         [TestMethod]
         public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnDecodeByteArray()
         {
-            CustomAlphabetEncoder testEncoder = new CustomAlphabetEncoder("abc");
+            var testEncoder = new CustomAlphabetEncoder("abc");
             string data = null;
 
             Action decodeAction = () => testEncoder.Decode(data);
             decodeAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void CustomAlphabetEncoder_VerifyStaticAndInstanceDate()
+        {
+            var testEncoder1 = new CustomAlphabetEncoder("abcdef");
+            uint randomChecksum = uint.MaxValue - 1000;
+
+            string encodedChecksum1 = testEncoder1.Encode(randomChecksum);
+
+            var testEncoder2 = new CustomAlphabetEncoder("abdefghijklmnopqrstuv");
+
+            string encodedChecksum2 = testEncoder1.Encode(randomChecksum);
+
+            encodedChecksum1.Should().Be(encodedChecksum2);
         }
     }
 }

--- a/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
+++ b/src/Tests.Marvin/CustomAlphabetEncoderTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -12,72 +16,166 @@ namespace Microsoft.Security.Utilities
     public class CustomAlphabetEncoderTests
     {
         [TestMethod]
-        [DataRow("399Wq7", 2883656711, null)]
-        [DataRow("", null, null)]
-        public void CustomAlphabetEncoder_EncodeUintWithDefaultAlphabet(string expected, uint input, string alphabet)
+        public void CustomAlphabetEncoder_EncodeUintWithTestCases()
         {
-            var testEncoder = new CustomAlphabetEncoder(alphabet);
-            string actualEncoded = testEncoder.Encode(input);
-            Assert.AreEqual(expected, actualEncoded);
+            Random random = new Random();
 
-            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
-            uint actualDecodedUint = BitConverter.ToUInt32(actualDecoded, 0);
+            var testCases = new[]
+            {
+                new {
+                    Alphabet = String.Empty,
+                    Input = uint.MinValue,
+                    ExpectedEncoded = ""
+                },
+                new
+                {
+                    Alphabet = String.Empty,
+                    Input = uint.MaxValue,
+                    ExpectedEncoded = "4gfFC3"
+                },
+                new
+                {
+                    Alphabet = String.Empty,
+                    Input = (uint)2883656711,
+                    ExpectedEncoded = "399Wq7"
+                },
+                new
+                {
+                    Alphabet = "abc",
+                    Input = (uint)2883656711,
+                    ExpectedEncoded = "cbbaccccaacccbbaabac"
+                },
+                new
+                {
+                    Alphabet = "abcdef",
+                    Input = UInt32.MinValue,
+                    ExpectedEncoded = ""
+                },
+                new
+                {
+                    Alphabet = "abcdef",
+                    Input = (uint)123456,
+                    ExpectedEncoded = "cdfbdca"
+                },
+            };
 
-            Assert.AreEqual(input, actualDecodedUint);
+            foreach (var testCase in testCases)
+            {
+                var testEncoder = new CustomAlphabetEncoder(testCase.Alphabet);
+                string actualEncoded = testEncoder.Encode(testCase.Input);
+
+                byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+                uint actualDecodedUint = BitConverter.ToUInt32(actualDecoded, 0);
+
+                actualEncoded.Should().Be(testCase.ExpectedEncoded);
+                actualDecodedUint.Should().Be(testCase.Input);
+            }
         }
 
         [TestMethod]
-        [DataRow("ABC123", (uint)123456)]
-        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", (uint)123456)]
-        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", UInt32.MinValue)]
-        [DataRow("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-_~", UInt32.MaxValue)]
-        public void CustomAlphabetEncoder_EncodeByteArrayWithCustomAlphabet(string alphabet, uint input)
+        public void CustomAlphabetEncoder_ShouldEncodeAndDecodeValidAlphabets()
         {
-            var testEncoder = new CustomAlphabetEncoder(alphabet);
-            byte[] expectedDecoded = BitConverter.GetBytes(input);
+            var random = new Random();
 
-            string actualEncoded = testEncoder.Encode(input);
-            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+            var testInputs = new List<uint>
+            {
+                uint.MinValue,
+                uint.MaxValue,
+                (uint)random.Next(),
+                (uint)random.Next(),
+                (uint)random.Next()
+            };
 
-            actualDecoded.Should().BeEquivalentTo(expectedDecoded);
+            foreach(string alphabet in GenerateValidAlphabetTestCases())
+            {
+                var testEncoder = new CustomAlphabetEncoder(alphabet);
+
+                foreach (uint input in testInputs)
+                {
+                    string actualEncoded = testEncoder.Encode(input);
+
+                    byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+                    uint actualDecodedUint = BitConverter.ToUInt32(actualDecoded, 0);
+
+                    actualDecodedUint.Should().Be(input);
+                }
+            }
         }
 
         [TestMethod]
-        [DataRow("abc", "abc")]
-        [DataRow("abc", "abcdef")]
-        [DataRow(".!@#$%&*", "abcdef")]
-        public void CustomAlphabetEncoder_EncodeByteArrayFromStringWithCustomAlphabet(string alphabet, string input)
+        public void CustomAlphabetEncoder_ShouldThrowInvalidArgumentExceptionIfAlphabetIsInvalid()
         {
-            var testEncoder = new CustomAlphabetEncoder(alphabet);
-            int data = input.GetHashCode();
-            byte[] expected = BitConverter.GetBytes(data);
+            var testCases = new[]
+            {
+                new {
+                    Alphabet = "a",
+                    ExpectedException = new ArgumentException("customAlphabet", "Alphabet must be at least 2 characters.")
+                },
+                new {
+                    Alphabet = "aaa",
+                    ExpectedException = new ArgumentException("customAlphabet", "Duplicate value detected in the alphabet.")
+                },
+                new {
+                    Alphabet = GenerateAsciiString(),
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "abc\uD800",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "abc\uDC00",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = GenerateAsciiString(130,132),
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "₼abc",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "ﺀabc",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "∞abc",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+                new {
+                    Alphabet = "µabc",
+                    ExpectedException = new ArgumentException("customAlphabet", "Forbidden character type detected in the alphabet.")
+                },
+            };
 
-            string actualEncoded = testEncoder.Encode((uint)data);
-            byte[] actualDecoded = testEncoder.Decode(actualEncoded);
+            foreach(var testCase in testCases)
+            {
+                Action action = () => new CustomAlphabetEncoder(testCase.Alphabet);
 
-            actualDecoded.Should().BeEquivalentTo(expected);
+                action.Should().Throw<ArgumentException>().WithMessage(testCase.ExpectedException.Message);
+            }
         }
 
         [TestMethod]
-        [DataRow("abcabc")]
-        [DataRow("abbc")]
-        [DataRow("11 2 3")]
-        [DataRow("1 2 3 a b c")]
-        public void CustomAlphabetEncoder_ShouldThrowInvalidArgumentExceptionIfCharacterRepeats(string alphabet)
-        {
-            Action action = () => new CustomAlphabetEncoder(alphabet);
-
-            action.Should().Throw<ArgumentException>();
-        }
-
-        [TestMethod]
-        public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnDecodeByteArray()
+        public void CustomAlphabetEncoder_ShouldThrowExceptionWithNullInputOnDecode()
         {
             var testEncoder = new CustomAlphabetEncoder("abc");
             string data = null;
 
             Action decodeAction = () => testEncoder.Decode(data);
             decodeAction.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void CustomAlphabetEncoder_ShouldThrowExceptionIfDecodedCharNotInAlphabet()
+        {
+            string alphabet = "abc";
+            string encodedInput = "123";
+            var testEncoder = new CustomAlphabetEncoder(alphabet);
+
+            Action decodeAction = () => testEncoder.Decode(encodedInput);
+            decodeAction.Should().Throw<ArgumentException>();
         }
 
         [TestMethod]
@@ -93,6 +191,40 @@ namespace Microsoft.Security.Utilities
             string encodedChecksum2 = testEncoder1.Encode(randomChecksum);
 
             encodedChecksum1.Should().Be(encodedChecksum2);
+        }
+
+        private IEnumerable<string> GenerateValidAlphabetTestCases()
+        {
+            Random random = new Random();
+
+            var output = new List<string>
+            {
+                String.Empty,
+                "ab",
+            };
+
+            // generate a sample of random test alphabets
+            for (int i = 0; i < 10; i++)
+            {
+                int low = random.Next(33, 120);
+                int high = random.Next(low+1, 127);
+
+                output.Add(GenerateAsciiString(low, high));
+            }
+
+            return output;
+        }
+
+        private string GenerateAsciiString(int low = 0, int high = 256)
+        {
+            var sb = new StringBuilder();
+
+            for(int i = low; i < high; i++)
+            {
+                sb.Append((char)i);
+            }
+
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
Adding class to allow encoding given a custom alphabet sequence. Testing scenarios include, encode and decode produce consistent results for a given alphabet, encode produces expected strings for given inputs and alphabets, and unsupported input throws the correct error.