### PR TITLE
Fixing the package version

### DIFF
--- a/src/Build.props
+++ b/src/Build.props
@@ -24,7 +24,7 @@
     <AssemblyOriginatorKeyFile>$(MsBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Label="Package" Condition="$(IsTestProject) != 'true'">
+  <PropertyGroup Label="Package" Condition="$(IsPackable) == 'true'">
     <Authors>Microsoft</Authors>
     <RootNamespace>Microsoft.Security.Utilities</RootNamespace>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -44,14 +44,14 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Label="SourceLink" Condition="$(IsTestProject) != 'true'">
+  <PropertyGroup Label="SourceLink" Condition="$(IsPackable) == 'true'">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(Configuration)' == 'Release' AND $(IsTestProject) != 'true'">
+  <ItemGroup Condition=" '$(Configuration)' == 'Release' AND $(IsPackable) == 'true'">
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
   </ItemGroup>
 
@@ -59,8 +59,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Label="Common Packages" Condition="$(IsTestProject) != 'true'">
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244">
+  <ItemGroup Label="Common Packages" Condition="$(IsPackable) == 'true'">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Marvin/Marvin.csproj
+++ b/src/Marvin/Marvin.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="$(MSBuildThisFileDirectory)..\Build.props" />
 
   <PropertyGroup Label="Package">
     <Title>$(RootNamespace)</Title>
     <PackageId>$(RootNamespace)</PackageId>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'net452'">

--- a/src/Tests.Marvin/Tests.Marvin.csproj
+++ b/src/Tests.Marvin/Tests.Marvin.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
+    <TargetFrameworks>net452;net461;net472;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\Build.props" />
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
## Description
Today, if we try to build and release a package with the current code, it will always generate a package 1.0.0 independently of what is the versioning described in `version.json`.

## Fix
This change will fix the package version and re-use an available variable (IsPackable) to check if the properties should be used or not during build/release.