### PR TITLE
Provide for URL-friendly base64-encoding.

### DIFF
--- a/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Security.Utilities
             return signatureBytes;
         }
 
-        private static byte[] ConvertFromBase64String(string text)
+        internal static byte[] ConvertFromBase64String(string text)
         {
             text = text.Replace('-', '+');
             text = text.Replace('_', '/');

--- a/src/Microsoft.Security.Utilities/Microsoft.Security.Utilities.csproj
+++ b/src/Microsoft.Security.Utilities/Microsoft.Security.Utilities.csproj
@@ -19,4 +19,22 @@
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Collections.Immutable">
+      <Version>6.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Collections.Immutable">
+      <Version>6.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Collections.Immutable">
+      <Version>6.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Security.Utilities/Microsoft.Security.Utilities.csproj
+++ b/src/Microsoft.Security.Utilities/Microsoft.Security.Utilities.csproj
@@ -20,21 +20,4 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>6.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>6.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>6.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Security.Utilities
                 yield return secret;
             }
         }
+
         private static HashSet<char> GetBase64Alphabet(bool encodeForUrl)
         {
             var alphabet = new HashSet<char>(new char[] {

--- a/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Security.Utilities
     [TestClass]
     public class IdentifiableSecretsTests
     {
-        // Default values which are consistently consumed by tests for positive cases.
-        private const string DefaultSignature = "+Sig";
-        private const string DefaultSeedText = "DEFAULT0";
-        private readonly static ulong DefaultSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(DefaultSeedText).Reverse().ToArray(), 0);
-
         private static Random s_random;
         private static double s_randomSeed;
 
@@ -67,9 +62,10 @@ namespace Microsoft.Security.Utilities
 
         [TestMethod]
         public void IdentifiableSecrets_GenerateBase64Key_ShouldThrowExceptionForInvalidLengths()
-        {
-            ulong seed = DefaultSeed;
-            string signature = DefaultSignature;
+        {        
+            const string signature = "ABCD";
+            const string seedText = "DEFAULT0";
+            ulong seed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(seedText).Reverse().ToArray(), 0);
 
             foreach (bool encodeForUrl in new[] { true, false })
             {

--- a/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -12,76 +13,209 @@ namespace Microsoft.Security.Utilities
     [TestClass]
     public class IdentifiableSecretsTests
     {
-        private const string Seed = "DEFAULT0";
-        private const string Signature = "+Sig";
+        // Default values which are consistently consumed by tests for positive cases.
+        private const string DefaultSignature = "+Sig";
+        private const string DefaultSeedText = "DEFAULT0";
+        private readonly static ulong DefaultSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(DefaultSeedText).Reverse().ToArray(), 0);
 
-        [TestMethod]
-        public void IdentifiableSecrets_GenerateIdentifiableKey_ShouldThrowExceptionWhenLengthIsInvalid()
+        private static Random s_random;
+        private static double s_randomSeed;
+
+        static IdentifiableSecretsTests()
         {
-            ulong seed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(Seed).Reverse().ToArray(), 0);
-
-            Assert.ThrowsException<ArgumentException>(() =>
-                IdentifiableSecrets.GenerateBase64Key(seed,
-                                                            keyLengthInBytes: IdentifiableSecrets.MaximumGeneratedKeySize + 1,
-                                                            base64EncodedSignature: Signature));
-
-            Assert.ThrowsException<ArgumentException>(() =>
-                IdentifiableSecrets.GenerateBase64Key(seed,
-                                                            keyLengthInBytes: IdentifiableSecrets.MinimumGeneratedKeySize - 1,
-                                                            base64EncodedSignature: Signature));
-
-            Assert.ThrowsException<ArgumentException>(() =>
-                IdentifiableSecrets.GenerateBase64Key(seed,
-                                                            keyLengthInBytes: 32,
-                                                            base64EncodedSignature: null));
-
-            Assert.ThrowsException<ArgumentException>(() =>
-                IdentifiableSecrets.GenerateBase64Key(seed,
-                                                            keyLengthInBytes: 32,
-                                                            base64EncodedSignature: "bad-signature-length"));
+            s_randomSeed = DateTime.UtcNow.TimeOfDay.TotalMilliseconds;
+            s_random = new Random((int)s_randomSeed);
         }
 
         [TestMethod]
-        public void IdentifiableSecrets_ValidateKey_ShouldReturnFalseIfSecretIsInvalid()
+        public void IdentifiableSecrets_GenerateBase64Key_ShouldThrowExceptionWhenLengthIsInvalid()
         {
-            const int size = 32;
-            ulong seed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(Seed).Reverse().ToArray(), 0);
+            ulong seed = DefaultSeed;
+            string signature = DefaultSignature;
 
-            string secret = IdentifiableSecrets.GenerateBase64Key(seed,
-                                                                        keyLengthInBytes: size,
-                                                                        base64EncodedSignature: Signature);
-
-            string newSignature = Signature.ToLowerInvariant();
-            Assert.AreNotEqual(Signature, newSignature);
-
-            string newSecret = secret.Replace(Signature, newSignature);
-            var isValid = IdentifiableSecrets.ValidateKey(newSecret, seed, Signature);
-            Assert.IsFalse(isValid);
-
-            newSecret = secret.Remove(secret.Length - 3, 2).Insert(secret.Length - 3, "++");
-            isValid = IdentifiableSecrets.ValidateKey(newSecret, seed, Signature);
-            Assert.IsFalse(isValid);
-        }
-
-        [TestMethod]
-        public void IdentifiableSecrets_GenerateIdentifiableKey_ShouldBeValidKey()
-        {
-            ulong seed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(Seed).Reverse().ToArray(), 0);
-
-            var sizes = new uint[]
+            foreach (bool encodeForUrl in new[] { true, false })
             {
-                IdentifiableSecrets.MinimumGeneratedKeySize,
-                IdentifiableSecrets.MaximumGeneratedKeySize,
-                63, 64, 65, 66
+                Assert.ThrowsException<ArgumentException>(() =>
+                    IdentifiableSecrets.GenerateBase64Key(seed,
+                                                          keyLengthInBytes: IdentifiableSecrets.MaximumGeneratedKeySize + 1,
+                                                          signature,
+                                                          encodeForUrl));
+
+                Assert.ThrowsException<ArgumentException>(() =>
+                    IdentifiableSecrets.GenerateBase64Key(seed,
+                                                          keyLengthInBytes: IdentifiableSecrets.MinimumGeneratedKeySize - 1,
+                                                          signature,
+                                                          encodeForUrl));
+
+                Assert.ThrowsException<ArgumentException>(() =>
+                    IdentifiableSecrets.GenerateBase64Key(seed,
+                                                          keyLengthInBytes: 32,
+                                                          base64EncodedSignature: null,
+                                                          encodeForUrl));
+
+                Assert.ThrowsException<ArgumentException>(() =>
+                    IdentifiableSecrets.GenerateBase64Key(seed,
+                                                          keyLengthInBytes: 32,
+                                                          base64EncodedSignature: "this signature is too long",
+                                                          encodeForUrl));
+            }
+        }
+
+        [TestMethod]
+        [Timeout(1000 * 60 * 5)]
+        public void IdentifiableSecrets_GenerateBase64Key_Comprehensive()
+        {
+            Console.WriteLine($"The random values in this test were producing using the seed value: {s_randomSeed}");
+
+            // Timeouts in this test would generally indicate that the secret 
+            // generation code isn't reliably producing keys using the complete
+            // alphabet.
+
+            var keyLengthInBytesValues = new uint[]
+            {
+                IdentifiableSecrets.MinimumGeneratedKeySize, IdentifiableSecrets.MinimumGeneratedKeySize + 1,
+                IdentifiableSecrets.MinimumGeneratedKeySize + 2, IdentifiableSecrets.MinimumGeneratedKeySize + 3,
+                IdentifiableSecrets.MaximumGeneratedKeySize - 3, IdentifiableSecrets.MaximumGeneratedKeySize - 2,
+                IdentifiableSecrets.MaximumGeneratedKeySize - 2, IdentifiableSecrets.MaximumGeneratedKeySize - 1,
+                29, 30, 31, 32, 33, 34, 35,
+                63, 64, 65, 66, 67, 68, 69,
             };
 
-            foreach (uint size in sizes)
+            foreach (bool encodeForUrl in new[] { true, false })
             {
-                string secret = IdentifiableSecrets.GenerateBase64Key(seed, keyLengthInBytes: size, base64EncodedSignature: Signature);
+                foreach (uint keyLengthInBytes in keyLengthInBytesValues)
+                {
+                    foreach (ulong seed in GenerateSeedsTheIncludeAllBits())
+                    {
+                        foreach (string signature in GenerateSignaturesThatIncludeFullAlphabet(encodeForUrl))
+                        {
+                            foreach (string secret in GenerateSecretsThatIncludeFullAlphabet(seed,
+                                                                                             keyLengthInBytes,
+                                                                                             signature,
+                                                                                             encodeForUrl))
+                            {
 
-                var isValid = IdentifiableSecrets.ValidateKey(secret, seed, Signature);
-                Assert.IsTrue(isValid);
+                                var isValid = IdentifiableSecrets.ValidateBase64Key(secret, seed, signature, encodeForUrl);
+                                Assert.IsTrue(isValid);
+
+                                // Next, we validate that modifying the seed, signature or 
+                                // the generated token data itself ensures validation fails.
+                                ulong newSeed = ~seed;
+                                Assert.AreNotEqual(seed, newSeed);
+                                isValid = IdentifiableSecrets.ValidateBase64Key(secret, newSeed, signature, encodeForUrl);
+                                Assert.IsFalse(isValid);
+
+                                string newSignature = GetReplacementCharacter(signature[0]) + signature.Substring(1);
+                                Assert.AreNotEqual(signature, newSignature);
+                                isValid = IdentifiableSecrets.ValidateBase64Key(secret, seed, newSignature, encodeForUrl);
+                                Assert.IsFalse(isValid);
+
+                                string newSecret = GetReplacementCharacter(secret[0]) + secret.Substring(1);
+                                Assert.AreNotEqual(secret, newSecret);
+                                isValid = IdentifiableSecrets.ValidateBase64Key(newSecret, seed, signature, encodeForUrl);
+                                Assert.IsFalse(isValid);
+                            }
+                        }
+                    }
+                }
             }
+        }
+
+        IEnumerable<ulong> GenerateSeedsTheIncludeAllBits()
+        {
+            ulong bitsObserved = 0;
+
+            while (bitsObserved != ulong.MaxValue)
+            {
+                uint value1 = (uint)s_random.Next(int.MinValue, int.MaxValue);
+                uint value2 = (uint)s_random.Next(int.MinValue, int.MaxValue);
+
+                ulong seed = value1 | (ulong)value2 << 32;
+                bitsObserved |= seed;
+                yield return seed;
+            }
+        }
+
+        IEnumerable<string> GenerateSignaturesThatIncludeFullAlphabet(bool encodeForUrl)
+        {
+            // This yield iterator will continue to generate secrets until all
+            // 64 characters of the desired encoding has appeared in at least
+            // one secret.
+
+            var alphabet = GetBase64Alphabet(encodeForUrl).ToList();
+
+            while (alphabet.Count > 0)
+            {
+                string signature = GenerateRandomSignature(encodeForUrl, alphabet);
+
+                foreach (char ch in signature) { alphabet.Remove(ch); }
+                yield return signature;
+            }
+        }
+
+        private string GenerateRandomSignature(bool encodeForUrl, IList<char> alphabet)
+        {
+            int maxValue = alphabet.Count - 1;
+            return string.Concat(alphabet[s_random.Next(0, maxValue)],
+                                 alphabet[s_random.Next(0, maxValue)],
+                                 alphabet[s_random.Next(0, maxValue)],
+                                 alphabet[s_random.Next(0, maxValue)]);
+        }
+
+        IEnumerable<string> GenerateSecretsThatIncludeFullAlphabet(ulong seed,
+                                                                   uint keyLengthInBytes,
+                                                                   string signature,
+                                                                   bool encodeForUrl)
+        {
+            // This yield iterator will continue to generate secrets until all
+            // 64 characters of the desired encoding has appeared in at least
+            // one secret.
+
+            HashSet<char> alphabet = GetBase64Alphabet(encodeForUrl);
+
+            while (alphabet.Count > 0)
+            {
+                string secret = IdentifiableSecrets.GenerateBase64Key(seed,
+                                                                      keyLengthInBytes,
+                                                                      signature,
+                                                                      encodeForUrl);
+
+                foreach (char ch in secret) { alphabet.Remove(ch); }
+                yield return secret;
+            }
+        }
+        private static HashSet<char> GetBase64Alphabet(bool encodeForUrl)
+        {
+            var alphabet = new HashSet<char>(new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'});
+
+            if (encodeForUrl)
+            {
+                alphabet.Add('-');
+                alphabet.Add('_');
+            }
+            else
+            {
+                alphabet.Add('+');
+                alphabet.Add('/');
+            }
+
+            return alphabet;
+        }
+
+        private string GetReplacementCharacter(char ch)
+        {
+            // Generate a replacement character that works for all possible
+            // generated characters in secrets, whether or not they are encoded
+            // with the standard or URL-friendly base64 alphabet.
+
+            if (!Char.IsLetter(ch)) { return "x"; }
+
+            return Char.IsUpper(ch)
+                ? ch.ToString().ToLowerInvariant()
+                : ch.ToString().ToUpperInvariant();
         }
     }
 }

--- a/src/Tests.Microsoft.Security.Utilities/Tests.Microsoft.Security.Utilities.csproj
+++ b/src/Tests.Microsoft.Security.Utilities/Tests.Microsoft.Security.Utilities.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />


### PR DESCRIPTION
Many security model providers have a need to generate bearer tokens that are base64-encoded, but which are 'URL friendly', i.e., which don't contain characters, such as the '=', '+' and '/' characters that need to be encoded in a URL. A common convention is to replace the '+' character with '-' (hyphen) and '/' with '_' (underscore) and to elide all '=' padding entirely.

I've updated the GenerateBase64Key method with a new parameter, 'encodeForUrl' that swaps in this alternate convention.

I've also updated the tests significantly and there should be some value in observing what I've done. This API is intended to support an extremely critical operation, the production of a generated secret. As such, there is a particularly stringent need for comprehensive testing.

@cfaucon @marmegh, @eddynaka, @EasyRhinoMSFT, @yongyan-gh, @shaopeng-gh @daniellegonzalez