### PR TITLE
Adding release history documentation.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,0 +1,10 @@
+# SecurityUtilities Release History
+
+## Unreleased
+* Breaking** Renamed IdentifiableSecrets.GenerateIdentifiableKey to IdentifiableSecrets.GenerateBase64Key.
+
+## **v1.1.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.1.0)
+* FEATURE: CustomAlphabetEncoder class added to support checksum validations.
+
+## **v1.0.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.0.0)
+* FEATURE: Initial release. Including Marvin and IdentifiableSecrets classes.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
-# SecurityUtilities Release History
+# Microsoft.Security.Utilities Release History
 
 ## Unreleased
-* Breaking** Renamed IdentifiableSecrets.GenerateIdentifiableKey to IdentifiableSecrets.GenerateBase64Key.
+* BREAKING: Renamed IdentifiableSecrets.GenerateIdentifiableKey to IdentifiableSecrets.GenerateBase64Key.
 
 ## **v1.1.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.1.0)
 * FEATURE: CustomAlphabetEncoder class added to support checksum validations.


### PR DESCRIPTION
Address issue #11. Release history was missing from first two releases. Backfilling documentation to include key features from v1.0.0 and v1.1.0; plus pending changes.