### PR TITLE
Split key generation for URL-safe and standard base64-encoding. 

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,10 +1,13 @@
 # Microsoft.Security.Utilities Release History
 
+## **v1.3.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.3.0)
+* BREAKING: Removed `encodeForUrl` parameter from `IdentifiableSecrets.GenerateBase64Key` method, and so this method is restricted to generating keys using the standard base64-encoding alphabet. Added a new method, `GenerateUrlCompatibleBase64Key` method for the URL-friendly case (with an option to include or exclude padding).
+
 ## **v1.2.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.2.0)
-* BREAKING: Renamed IdentifiableSecrets.GenerateIdentifiableKey to IdentifiableSecrets.GenerateBase64Key.
+* BREAKING: Renamed `IdentifiableSecrets.GenerateIdentifiableKey to IdentifiableSecrets.GenerateBase64Key.
 
 ## **v1.1.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.1.0)
-* FEATURE: CustomAlphabetEncoder class added to support checksum validations.
+* FEATURE: `CustomAlphabetEncoder` class added to support checksum validations.
 
 ## **v1.0.0** [NuGet Package](https://www.nuget.org/packages/Microsoft.Security.Utilities/1.0.0)
-* FEATURE: Initial release. Including Marvin and IdentifiableSecrets classes.
+* FEATURE: Initial release. Including `Marvin` and `IdentifiableSecrets` classes.

--- a/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
@@ -44,9 +44,10 @@ namespace Microsoft.Security.Utilities
         /// for a full 64-character alphabet that can be decoded by standard API in .NET, 
         /// Go, etc.
         /// </summary>
-        /// <param name="checksumSeed"></param>
-        /// <param name="keyLengthInBytes">The size of the secret.</param>
-        /// <param name="base64EncodedSignature">The signature that will be encoded in the identifiable secret.</param>
+        /// <param name="checksumSeed">A seed value that initializes the Marvin checksum algorithm.</param>
+        /// <param name="keyLengthInBytes">The size of the secret in bytes.</param>
+        /// <param name="base64EncodedSignature">The signature that will be encoded in the identifiable secret. 
+        /// This string must only contain valid URL-safe base64-encoding characters.</param>
         /// <returns></returns>
         public static string GenerateUrlSafeBase64Key(ulong checksumSeed,
                                                       uint keyLengthInBytes,
@@ -67,6 +68,13 @@ namespace Microsoft.Security.Utilities
             return elidePadding ? secret.TrimEnd('=') : secret;
         }
 
+
+        /// </summary>
+        /// <param name="checksumSeed">A seed value that initializes the Marvin checksum algorithm.</param>
+        /// <param name="keyLengthInBytes">The size of the secret in bytes.</param>
+        /// <param name="base64EncodedSignature">The signature that will be encoded in the identifiable secret. 
+        /// This string must only contain valid base64-encoding characters.</param>
+        /// <returns></returns>
         public static string GenerateStandardBase64Key(ulong checksumSeed,
                                                        uint keyLengthInBytes,
                                                        string base64EncodedSignature)

--- a/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
@@ -239,8 +239,8 @@ namespace Microsoft.Security.Utilities
                     // The following condition should always be true, since we 
                     // have already verified the checksum earlier in this routine.
                     // We explode all conditions in this check in order to
-                    // conclusively validate (via code coverage) that all 
-                    // conditions are met.
+                    // 'convince' VS code coverage these conditions are 
+                    // exhaustively covered.
                     Debug.Assert(firstChar == 'A' || firstChar == 'B' ||
                                  firstChar == 'C' || firstChar == 'D' ||
                                  firstChar == 'E' || firstChar == 'F' ||

--- a/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities/IdentifiableSecrets.cs
@@ -36,18 +36,54 @@ namespace Microsoft.Security.Utilities
         }
 
         /// <summary>
-        /// Generate an identifiable secret rendered in the standard base64-encoding alphabet.
+        /// Generate an identifiable secret with a URL-compatible format (replacing all '+'
+        /// characters with '-' and all '/' characters with '_') and eliding all padding
+        /// characters (unless the caller chooses to retain them). Strictly speaking, only
+        /// the '+' character is incompatible for tokens expressed as a query string
+        /// parameter. For this case, however, replacing the '/ character as well allows
+        /// for a full 64-character alphabet that can be decoded by standard API in .NET, 
+        /// Go, etc.
         /// </summary>
         /// <param name="checksumSeed"></param>
         /// <param name="keyLengthInBytes">The size of the secret.</param>
         /// <param name="base64EncodedSignature">The signature that will be encoded in the identifiable secret.</param>
-        /// <param name="encodeForUrl">'true' if the returned token should be encoded in a URL-compatible form 
-        /// (replacing the '+' and '/' characters and dropping any padding).</param>
         /// <returns></returns>
-        public static string GenerateBase64Key(ulong checksumSeed,
-                                               uint keyLengthInBytes,
-                                               string base64EncodedSignature,
-                                               bool encodeForUrl = false)
+        public static string GenerateUrlSafeBase64Key(ulong checksumSeed,
+                                                      uint keyLengthInBytes,
+                                                      string base64EncodedSignature,
+                                                      bool elidePadding)
+        {
+            string secret = GenerateBase64KeyHelper(checksumSeed,
+                                                    keyLengthInBytes,
+                                                    base64EncodedSignature,
+                                                    encodeForUrl: true);
+
+            // The '=' padding must be encoded in some URL contexts but can be 
+            // directly expressed in others, such as a query string parameter.
+            // Additionally, some URL Base64 Encoders (such as Azure's 
+            // Base64UrlEncoder class) expect padding to be removed while
+            // others (such as Go's Base64.URLEncoding helper) expect it to
+            // exist. We therefore provide an option to express it or not.
+            return elidePadding ? secret.TrimEnd('=') : secret;
+        }
+
+        public static string GenerateStandardBase64Key(ulong checksumSeed,
+                                                       uint keyLengthInBytes,
+                                                       string base64EncodedSignature)
+        {
+            return GenerateBase64KeyHelper(checksumSeed,
+                                           keyLengthInBytes,
+                                           base64EncodedSignature,
+                                           encodeForUrl: false);
+        }
+
+
+        // This helper is a primary focus of unit-testing, due to the fact it
+        // contains the majority of the logic for base64-encoding scenarios.
+        internal static string GenerateBase64KeyHelper(ulong checksumSeed,
+                                                      uint keyLengthInBytes,
+                                                      string base64EncodedSignature,
+                                                      bool encodeForUrl)
         {
             if (keyLengthInBytes > MaximumGeneratedKeySize)
             {
@@ -168,7 +204,6 @@ namespace Microsoft.Security.Utilities
 
             if (equalsSignIndex > -1)
             {
-                Debug.Assert(encodeForUrl == false);
                 equalsSigns = key.Substring(equalsSignIndex);
                 prefixLength = equalsSignIndex - lengthOfEncodedChecksum - base64EncodedSignature.Length;
             }
@@ -203,7 +238,17 @@ namespace Microsoft.Security.Utilities
 
                     // The following condition should always be true, since we 
                     // have already verified the checksum earlier in this routine.
-                    Debug.Assert(firstChar >= 'A' && firstChar <= 'P');
+                    // We explode all conditions in this check in order to
+                    // conclusively validate (via code coverage) that all 
+                    // conditions are met.
+                    Debug.Assert(firstChar == 'A' || firstChar == 'B' ||
+                                 firstChar == 'C' || firstChar == 'D' ||
+                                 firstChar == 'E' || firstChar == 'F' ||
+                                 firstChar == 'G' || firstChar == 'H' ||
+                                 firstChar == 'I' || firstChar == 'J' ||
+                                 firstChar == 'K' || firstChar == 'L' ||
+                                 firstChar == 'M' || firstChar == 'N' ||
+                                 firstChar == 'O' || firstChar == 'P');
                     break;
                 }
 
@@ -216,7 +261,8 @@ namespace Microsoft.Security.Utilities
 
                     // The following condition should always be true, since we 
                     // have already verified the checksum earlier in this routine.
-                    Debug.Assert(firstChar >= 'A' && firstChar <= 'D');
+                    Debug.Assert(firstChar == 'A' || firstChar == 'B' ||
+                                 firstChar == 'C' || firstChar == 'D');
                     break;
                 }
 
@@ -351,18 +397,29 @@ namespace Microsoft.Security.Utilities
             return signatureBytes;
         }
 
+        internal static string TransformToUrlSafeEncoding(string base64EncodedText)
+        {
+            return base64EncodedText.Replace('+', '-').Replace('/', '_');
+        }
+
+        internal static string TransformToStandardEncoding(string urlSafeBase64EncodedText)
+        {
+            return urlSafeBase64EncodedText.Replace('-', '+').Replace('_', '/');
+        }
+
+        internal static string RetrievePaddingForBase64EncodedText(string text)
+        {
+            int paddingCount = 4 - text.Length % 4;
+             
+            return (!text.EndsWith("=") && paddingCount < 3)
+                ? new string('=', paddingCount)
+                : string.Empty;
+        }
+
         internal static byte[] ConvertFromBase64String(string text)
         {
-            text = text.Replace('-', '+');
-            text = text.Replace('_', '/');
-
-            int paddingCount = 4 - text.Length % 4;
-
-            if (paddingCount < 3)
-            {
-                text += new string('=', paddingCount);
-            }
-
+            text = TransformToStandardEncoding(text);
+            text += RetrievePaddingForBase64EncodedText(text);
             return Convert.FromBase64String(text);
         }
 
@@ -372,11 +429,8 @@ namespace Microsoft.Security.Utilities
 
             if (encodeForUrl)
             {
-                text = text.Replace('+', '-');
-                text = text.Replace('/', '_');
-                text = text.TrimEnd('=');
+                text = TransformToUrlSafeEncoding(text);
             }
-
             return text;
         }
     }

--- a/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
+
+using FluentAssertions;
 
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -69,25 +72,25 @@ namespace Microsoft.Security.Utilities
             foreach (bool encodeForUrl in new[] { true, false })
             {
                 Assert.ThrowsException<ArgumentException>(() =>
-                    IdentifiableSecrets.GenerateBase64Key(seed,
+                    IdentifiableSecrets.GenerateBase64KeyHelper(seed,
                                                           keyLengthInBytes: IdentifiableSecrets.MaximumGeneratedKeySize + 1,
                                                           signature,
                                                           encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
-                    IdentifiableSecrets.GenerateBase64Key(seed,
+                    IdentifiableSecrets.GenerateBase64KeyHelper(seed,
                                                           keyLengthInBytes: IdentifiableSecrets.MinimumGeneratedKeySize - 1,
                                                           signature,
                                                           encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
-                    IdentifiableSecrets.GenerateBase64Key(seed,
+                    IdentifiableSecrets.GenerateBase64KeyHelper(seed,
                                                           keyLengthInBytes: 32,
                                                           base64EncodedSignature: null,
                                                           encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
-                    IdentifiableSecrets.GenerateBase64Key(seed,
+                    IdentifiableSecrets.GenerateBase64KeyHelper(seed,
                                                           keyLengthInBytes: 32,
                                                           base64EncodedSignature: "this signature is too long",
                                                           encodeForUrl));
@@ -114,17 +117,21 @@ namespace Microsoft.Security.Utilities
                     // If the injected character is legal, we'll go ahead and validate everything works as expected.
                     if (alphabet.Contains(injectedChar))
                     {
-                        string secret = IdentifiableSecrets.GenerateBase64Key(seed, keyLengthInBytes, signature, encodeForUrl);
+                        string secret = IdentifiableSecrets.GenerateBase64KeyHelper(seed,
+                                                                                    keyLengthInBytes,
+                                                                                    signature,
+                                                                                    encodeForUrl);
+
                         ValidateSecret(secret, seed, signature, encodeForUrl);
                         continue;
                     }
 
                     // All illegal characters in the signature should raise an exception.
                     Assert.ThrowsException<ArgumentException>(() =>
-                        IdentifiableSecrets.GenerateBase64Key(seed,
-                                                              keyLengthInBytes,
-                                                              signature,
-                                                              encodeForUrl));
+                        IdentifiableSecrets.GenerateBase64KeyHelper(seed,
+                                                                    keyLengthInBytes,
+                                                                    signature,
+                                                                    encodeForUrl));
 
                 }
             }
@@ -171,26 +178,99 @@ namespace Microsoft.Security.Utilities
             }
         }
 
+        [TestMethod]
+        public void IdentifiableSecrets_RetrievePaddingForBase64EncodedText()
+        {
+            using var cryptoProvider = new RNGCryptoServiceProvider();
+
+            for (int i = 0; i < 256; i++)
+            {
+                var randomBytes = new byte[i];
+                cryptoProvider.GetBytes(randomBytes);
+
+                string base64Encoded = Convert.ToBase64String(randomBytes);
+
+                // First, we make sure that our helper properly recognizes existing padding on 
+                // a base64-encoded strings. Note that this helper assumes that any padding
+                // that exists is valid. I.e., is present because it needs to be, is the 
+                // appropriate # of characters, etc.
+                string reconstructed = base64Encoded;
+                reconstructed += IdentifiableSecrets.RetrievePaddingForBase64EncodedText(reconstructed);
+                reconstructed.Should().Be(base64Encoded);
+
+                // Now we trim any padding off the base64-encoded text and ensure we can restore it.
+                reconstructed = base64Encoded.TrimEnd('=');
+                reconstructed += IdentifiableSecrets.RetrievePaddingForBase64EncodedText(reconstructed);
+                reconstructed.Should().Be(base64Encoded);
+            }
+        }
+
+        private enum Base64EncodingKind
+        {
+            Unknown,
+            Standard,
+            UrlSafe
+        }
+
         private void ValidateSecret(string secret, ulong seed, string signature, bool encodeForUrl)
         {
             var isValid = IdentifiableSecrets.ValidateBase64Key(secret, seed, signature, encodeForUrl);
             Assert.IsTrue(isValid);
 
-            if (encodeForUrl)
-            {
-                // This code path ensures that our API mechanism to replace certain characters in a
-                // base64-encoded string provides the functional equivalent to calling an actual
-                // Azure API that provides URL friendly base64-encoding. We don't actually take a 
-                // dependency on this package in order to minimize the packages that our API
-                // itself has a dependency on. This ensures our behavior is strictly identical
-                // to that more official code, however.
-                byte[] apiDecodedBytes = IdentifiableSecrets.ConvertFromBase64String(secret);
-                byte[] azureDecodedBytes = Base64UrlEncoder.DecodeBytes(secret);
+            var base64EncodingKind = Base64EncodingKind.Unknown;
 
-                Assert.AreEqual(apiDecodedBytes.Length, azureDecodedBytes.Length);
-                for (int i = 0; i < apiDecodedBytes.Length; i++)
+            if (secret.Contains('+') || secret.Contains('/'))
+            {
+                base64EncodingKind = Base64EncodingKind.Standard;
+            }
+            else if (secret.Contains('-') || secret.Contains('_'))
+            {
+                base64EncodingKind = Base64EncodingKind.UrlSafe;
+            }
+
+            byte[] apiDecodedBytes = IdentifiableSecrets.ConvertFromBase64String(secret);
+
+            switch (base64EncodingKind)
+            {
+                case Base64EncodingKind.Standard:
                 {
-                    Assert.AreEqual(apiDecodedBytes[i], azureDecodedBytes[i]);
+                    byte[] dotNetDecodedBytes = Convert.FromBase64String(secret);
+                    VerifyByteArraysAreEqual(apiDecodedBytes, dotNetDecodedBytes);
+
+                    string urlSafeEncoded = Base64UrlEncoder.Encode(dotNetDecodedBytes);
+                    string base64Encoded = IdentifiableSecrets.TransformToStandardEncoding(urlSafeEncoded);
+                    base64Encoded += IdentifiableSecrets.RetrievePaddingForBase64EncodedText(base64Encoded);
+
+                    base64Encoded.Should().Be(secret);
+                    break;
+                }
+                case Base64EncodingKind.UrlSafe:
+                {
+                    byte[] azureDecodedBytes = Base64UrlEncoder.DecodeBytes(secret);
+                    VerifyByteArraysAreEqual(apiDecodedBytes, azureDecodedBytes);
+
+                    string base64Encoded = Convert.ToBase64String(azureDecodedBytes);
+                    string urlSafeEncoded = IdentifiableSecrets.TransformToUrlSafeEncoding(base64Encoded);
+
+                    string padding = IdentifiableSecrets.RetrievePaddingForBase64EncodedText(secret);
+                    urlSafeEncoded.Should().Be(secret + padding);
+                    break;
+                }
+                case Base64EncodingKind.Unknown:
+                {
+                    secret += IdentifiableSecrets.RetrievePaddingForBase64EncodedText(secret);
+                    byte[] dotNetDecodedBytes = Convert.FromBase64String(secret);
+                    byte[] azureDecodedBytes = Base64UrlEncoder.DecodeBytes(secret);
+
+                    VerifyByteArraysAreEqual(apiDecodedBytes, dotNetDecodedBytes);
+                    VerifyByteArraysAreEqual(dotNetDecodedBytes, azureDecodedBytes);
+
+                    string base64Encoded = Convert.ToBase64String(apiDecodedBytes);
+                    string urlSafeEncoded = Base64UrlEncoder.Encode(dotNetDecodedBytes);
+
+                    Assert.IsTrue(base64Encoded == secret ||
+                                  urlSafeEncoded == secret.Trim('='));
+                    break;
                 }
             }
 
@@ -210,6 +290,15 @@ namespace Microsoft.Security.Utilities
             Assert.AreNotEqual(secret, newSecret);
             isValid = IdentifiableSecrets.ValidateBase64Key(newSecret, seed, signature, encodeForUrl);
             Assert.IsFalse(isValid);
+        }
+
+        private void VerifyByteArraysAreEqual(byte[] first, byte[] second)
+        {
+            Assert.AreEqual(first.Length, second.Length);
+            for (int i = 0; i < first.Length; i++)
+            {
+                Assert.AreEqual(first[i], second[i]);
+            }
         }
 
         IEnumerable<ulong> GenerateSeedsThatIncludeAllBits()
@@ -266,16 +355,29 @@ namespace Microsoft.Security.Utilities
 
             while (alphabet.Count > 0)
             {
-                string secret = IdentifiableSecrets.GenerateBase64Key(seed,
-                                                                      keyLengthInBytes,
-                                                                      signature,
-                                                                      encodeForUrl);
+                string secret;
+                if (!encodeForUrl)
+                {
+                    secret = IdentifiableSecrets.GenerateStandardBase64Key(seed,
+                                                                           keyLengthInBytes,
+                                                                           signature);
 
-                foreach (char ch in secret) { alphabet.Remove(ch); }
-                yield return secret;
+                    foreach (char ch in secret) { alphabet.Remove(ch); }
+                    yield return secret;
+                    continue;
+                }
+
+                foreach (bool elidePadding in new[] { true, false })
+                {
+                    secret = IdentifiableSecrets.GenerateUrlSafeBase64Key(seed,
+                                                                          keyLengthInBytes,
+                                                                          signature,
+                                                                          elidePadding);
+                    foreach (char ch in secret) { alphabet.Remove(ch); }
+                    yield return secret;
+                }
             }
         }
-
         private static HashSet<char> GetBase64Alphabet(bool encodeForUrl)
         {
             var alphabet = new HashSet<char>(new char[] {

--- a/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities/IdentifiableSecretsTests.cs
@@ -73,27 +73,27 @@ namespace Microsoft.Security.Utilities
             {
                 Assert.ThrowsException<ArgumentException>(() =>
                     IdentifiableSecrets.GenerateBase64KeyHelper(seed,
-                                                          keyLengthInBytes: IdentifiableSecrets.MaximumGeneratedKeySize + 1,
-                                                          signature,
-                                                          encodeForUrl));
+                                                                keyLengthInBytes: IdentifiableSecrets.MaximumGeneratedKeySize + 1,
+                                                                signature,
+                                                                encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
                     IdentifiableSecrets.GenerateBase64KeyHelper(seed,
-                                                          keyLengthInBytes: IdentifiableSecrets.MinimumGeneratedKeySize - 1,
-                                                          signature,
-                                                          encodeForUrl));
+                                                                keyLengthInBytes: IdentifiableSecrets.MinimumGeneratedKeySize - 1,
+                                                                signature,
+                                                                encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
                     IdentifiableSecrets.GenerateBase64KeyHelper(seed,
-                                                          keyLengthInBytes: 32,
-                                                          base64EncodedSignature: null,
-                                                          encodeForUrl));
+                                                                keyLengthInBytes: 32,
+                                                                base64EncodedSignature: null,
+                                                                encodeForUrl));
 
                 Assert.ThrowsException<ArgumentException>(() =>
                     IdentifiableSecrets.GenerateBase64KeyHelper(seed,
-                                                          keyLengthInBytes: 32,
-                                                          base64EncodedSignature: "this signature is too long",
-                                                          encodeForUrl));
+                                                                keyLengthInBytes: 32,
+                                                                base64EncodedSignature: "this signature is too long",
+                                                                encodeForUrl));
             }
         }
 
@@ -268,8 +268,8 @@ namespace Microsoft.Security.Utilities
                     string base64Encoded = Convert.ToBase64String(apiDecodedBytes);
                     string urlSafeEncoded = Base64UrlEncoder.Encode(dotNetDecodedBytes);
 
-                    Assert.IsTrue(base64Encoded == secret ||
-                                  urlSafeEncoded == secret.Trim('='));
+                    Assert.IsTrue(base64Encoded == secret && 
+                                  urlSafeEncoded == secret.TrimEnd('='));
                     break;
                 }
             }


### PR DESCRIPTION
Split apart methods for producing base64 keys encoded with URL friendly or standard alphabet.

It is useful to have a knob to control whether to elide padding from the token or not. Because we provide this capability, the validation and other logic handles cases where a URL safe key both does or does not have this padding.

There's ambiguity around whether to elide the '=' character in a URL. This character must be escaped in the primary components of the URL but it is fine for it to be in the clear in a query string parameter. An equal sign has a special meaning but only by convention in the query string, for expressing key/value pairs. Generally, these are separated by an ampersand character.

The 'safest' thing to do is to eliminate the '=' sign entirely but in practice this can render generated tokens less recognizable in the primary regex detection. i.e., the final '==' padding in a URL-safe encoded 40-byte value is helpful in reducing noise for the preliminary regex match.

@EasyRhinoMSFT @eddynaka @marmegh @shaopeng-gh @yongyan-gh