### PR TITLE
Add an API for generating derived keys from HIS keys.

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -298,11 +298,14 @@ public static class IdentifiableSecrets
         using var hmac = new HMACSHA256(keyBytes);
         byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(salt));
 
+        byte[] derivedKeyBytes = new byte[39];
+        Array.Copy(hashBytes, derivedKeyBytes, hashBytes.Length);
+
         derivedKey = GenerateBase64KeyHelper(~checksumSeed,
-                                             (uint)hashBytes.Length,
+                                             (uint)derivedKeyBytes.Length,
                                              signature,
                                              encodeForUrl: false,
-                                             hashBytes);
+                                             derivedKeyBytes);
 
         return derivedKey;
     }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -280,12 +280,10 @@ public static class IdentifiableSecrets
         return key;
     }
 
-    public static string GenerateDerivedSymmetricKey(string key, ulong checksumSeed, string salt)
+    public static string ComputeDerivedSymmetricKey(string key, ulong checksumSeed, string textToSign, bool encodeForUrl = false)
     {
         string signature = key.Trim('=');
         signature = signature.Substring(signature.Length - 10, 4);
-
-        bool encodeForUrl = key.Contains("-") || key.Contains("_");
 
         if (!TryValidateBase64Key(key, checksumSeed, signature, encodeForUrl))
         {
@@ -296,7 +294,7 @@ public static class IdentifiableSecrets
         byte[] keyBytes = Convert.FromBase64String(key);
 
         using var hmac = new HMACSHA256(keyBytes);
-        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(salt));
+        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(textToSign));
 
         byte[] derivedKeyBytes = new byte[39];
         Array.Copy(hashBytes, derivedKeyBytes, hashBytes.Length);

--- a/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
+++ b/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
@@ -28,7 +28,8 @@ public class SecretMasker : ISecretMasker, IDisposable
 
     private static Version RetrieveVersion()
     {
-        return new Version(ThisAssembly.AssemblyFileVersion);
+        var version = new Version(ThisAssembly.AssemblyFileVersion);
+        return new Version(version.Major, version.Minor, version.Build);
     }
 
     public SecretMasker(IEnumerable<RegexPattern>? regexSecrets, bool generateCorrelatingIds = false, IRegexEngine? regexEngine = default)

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Security.Utilities
                         if (IdentifiableSecrets.TryValidateBase64Key(testExample, checksumSeed, identifiablePattern.Signature))                        
                         {
                             matched = true;
-                            string salt = $"{Guid.NewGuid()}";
+                            string textToSign = $"{Guid.NewGuid()}";
 
                             // We found the seed for this test example.
-                            string derivedKey = IdentifiableSecrets.GenerateDerivedSymmetricKey(testExample, checksumSeed, salt);
+                            string derivedKey = IdentifiableSecrets.ComputeDerivedSymmetricKey(testExample, checksumSeed, textToSign);
                             bool isValid = IdentifiableSecrets.TryValidateBase64Key(derivedKey, ~checksumSeed, identifiablePattern.Signature);
                             isValid.Should().BeTrue(because: $"the '{pattern.Name} derived key '{derivedKey}' should validate");
                         }

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -21,7 +21,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.4.13.0");
+        version.ToString().Should().Be("1.4.13");
     }
 
     [TestMethod]


### PR DESCRIPTION
This is a draft of a PR to produce a derived symmetric key that's HIS compliant from an existing key. The approach is like so:

- First, validate that the input key conforms to the `highly identifiable secret` (HIS) v1 standard. This requires providing the checksum seed only (the signature is obtained from the key itself) and a textual input that uniquely identifies the derived key.
- Retrieve the signature from the key and generate a derived key checksum seed by XOR'ing the original.
- Using the input key as the secret, produce an HMAC cryptographic hash of the textual input.
- The resulting 32-byte hash is then transformed into an HIS v1 key by adding the fixed signature and the computed Marvin32 checksum of the HMAC, Marvin being initialized with the derived key checksum seed.

The output is a 39-byte base64-encoded value that preserve the full 32-byte HMAC bytes.

