### PR TITLE
Fix logic to retain original random bits.

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -204,6 +204,8 @@ public static class IdentifiableSecrets
 
             byte randomByte = keyBytes[keyBytes.Length - 18];
 
+            randomByte = (byte)(randomByte >> 4);
+
             int reserved = (randomByte << 12) | (sixBitsReserved1 << 6) | sixBitsReserved2;
             byte[] reservedBytes = BitConverter.GetBytes(reserved);
 


### PR DESCRIPTION
This issue only surfaces in test key production where we need to preserve specific patterns to enforce repetition of test key char.