### PR TITLE
Add `IdentifiableSecrets.ComputeChecksumSeed`

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -8,6 +8,9 @@
 - NEW -> New API or feature.
 - PRF => Performance work.
 
+# 1.4.18 - 05/09/2024
+- NEW: Add `IdentifiableSecrets._ComputeChecksumSeed` to derive checksum seeds from versioned string literals, e.g., `ReadKey0`.
+
 # 1.4.17 - 05/05/2024
 - PRF: Remove `SHA256` instance creation from `RegexPattern.GenerateCrossCompanyCorrelatingId` to avoid expensive object initialization costs.
 - PRF: Add `RegexOption.NonBacktracking` as a default option when available to improve .NET regex engine performance.

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -77,6 +78,29 @@ public static class IdentifiableSecrets
 
         return encoded == checksumText;
     }
+
+    public static ulong ComputeChecksumSeed(string versionedKeyKind, out string hexFormatted)
+    {
+        hexFormatted = null;
+
+        if (versionedKeyKind == null)
+        {
+            throw new ArgumentNullException(nameof(versionedKeyKind));
+        }
+
+        if (versionedKeyKind.Length != 8 ||
+            !char.IsDigit(versionedKeyKind[7]))
+        {
+            throw new ArgumentException("The versioned literal must be 8 characters long and end with a digit.");
+        }
+
+        ulong result = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(versionedKeyKind).Reverse().ToArray(), 0);
+
+        hexFormatted = $"0x{result.ToString("X").ToLowerInvariant()}";
+
+        return result;
+    }
+
 
     public static string GenerateCommonAnnotatedKey(ulong checksumSeed,
                                                     string base64EncodedSignature,

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -85,28 +85,34 @@ public static class IdentifiableSecrets
     /// seed is used to initialize the Marvin32 algorithm to watermark a specific class of
     /// generated security keys.
     /// </summary>
-    /// <param name="versionedKeyKind">A readable name that identifies a specific set of generated keys with at least one trailing digit in the name.</param>
-    /// <returns></returns>
+    /// <param name="keyKind">A 6-character readable name that identifies a specific set of generated keys.</param>
+    /// <param name="version">A number between 0 - 99 to encode in the checksum seed as a version.</param>
+    /// <returns>A checksum seed derived from the readable key kind name.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public static ulong ComputeChecksumSeed(string versionedKeyKind)
+    public static ulong ComputeChecksumSeed(string keyKind, uint version)
     {
-        if (versionedKeyKind == null)
+        if (keyKind == null)
         {
-            throw new ArgumentNullException(nameof(versionedKeyKind));
+            throw new ArgumentNullException(nameof(keyKind));
         }
 
-        if (versionedKeyKind.Length != 8 ||
-            !char.IsDigit(versionedKeyKind[7]))
+        if (keyKind.Length != 8 - $"{version:D2}".Length)
         {
-            throw new ArgumentException("The versioned literal must be 8 characters long and end with a digit.");
+            throw new ArgumentException("The keyKind value must be 6 characters long.");
+        }
+
+        if (version > 99)
+        {
+            throw new ArgumentException("Version value must be between 0 - 99.");
         }
 
         // We obtain the bytes of the string literal, reverse them and then convert them to a ulong.
         // Because the string literal has a trailing number, if this number is incremented, the next
         // version of the seed will be very close in number to previous versions. All of this work
         // attempting to ensure the versionability of seeds is future-proofing of uncertain value.
-        ulong result = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(versionedKeyKind).Reverse().ToArray(), 0);
+        string fullLiteral = $"{keyKind}{version:D2}";
+        ulong result = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(fullLiteral).Reverse().ToArray(), 0);
 
         return result;
     }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -79,10 +79,18 @@ public static class IdentifiableSecrets
         return encoded == checksumText;
     }
 
-    public static ulong ComputeChecksumSeed(string versionedKeyKind, out string hexFormatted)
+    /// <summary>
+    /// Generate a <see cref="ulong"/> checksum seed from a string literal that is 8 characters
+    /// long and ends with at least one digit, e.g., 'ReadKey0', 'RWSeed00', etc. The checksum
+    /// seed is used to initialize the Marvin32 algorithm to watermark a specific class of
+    /// generated security keys.
+    /// </summary>
+    /// <param name="versionedKeyKind">A readable name that identifies a specific set of generated keys with at least one trailing digit in the name.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public static ulong ComputeChecksumSeed(string versionedKeyKind)
     {
-        hexFormatted = null;
-
         if (versionedKeyKind == null)
         {
             throw new ArgumentNullException(nameof(versionedKeyKind));
@@ -99,8 +107,6 @@ public static class IdentifiableSecrets
         // version of the seed will be very close in number to previous versions. All of this work
         // attempting to ensure the versionability of seeds is future-proofing of uncertain value.
         ulong result = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(versionedKeyKind).Reverse().ToArray(), 0);
-
-        hexFormatted = $"0x{result.ToString("X").ToLowerInvariant()}";
 
         return result;
     }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -94,6 +94,10 @@ public static class IdentifiableSecrets
             throw new ArgumentException("The versioned literal must be 8 characters long and end with a digit.");
         }
 
+        // We obtain the bytes of the string literal, reverse them and then convert them to a ulong.
+        // Because the string literal has a trailing number, if this number is incremented, the next
+        // version of the seed will be very close in number to previous versions. All of this work
+        // attempting to ensure the versionability of seeds is future-proofing of uncertain value.
         ulong result = BitConverter.ToUInt64(Encoding.ASCII.GetBytes(versionedKeyKind).Reverse().ToArray(), 0);
 
         hexFormatted = $"0x{result.ToString("X").ToLowerInvariant()}";

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Security.Utilities
             for (int i = 0; i < 16; i++)
             {
                 string literal = $"{new string('A', i)}0";
-                Action action = () => IdentifiableSecrets.ComputeChecksumSeed(literal, out _);
+                Action action = () => IdentifiableSecrets.ComputeChecksumSeed(literal);
                 if (i == 7)
                 {
                     action.Should().NotThrow(because: $"literal '{literal}' should generate a valid seed");
@@ -53,7 +53,7 @@ namespace Microsoft.Security.Utilities
         public void IdentifiableSecrets_ComputeChecksumSeed_EnforcesNumericSuffix()
         {
             string literal = $"{new string('A', 8)}";
-            Action action = () => IdentifiableSecrets.ComputeChecksumSeed(literal, out _);
+            Action action = () => IdentifiableSecrets.ComputeChecksumSeed(literal);
             action.Should().Throw<ArgumentException>(because: $"literal '{literal}' should raise an exception as it has no trailing number");
 
             for (int i = 0; i < 10; i++)
@@ -76,8 +76,7 @@ namespace Microsoft.Security.Utilities
 
             foreach (var test in tests)
             {
-                IdentifiableSecrets.ComputeChecksumSeed(test.literal, out string hexFormatted).Should().Be(test.seed);
-                ulong.Parse(hexFormatted.Substring(2), System.Globalization.NumberStyles.HexNumber).Should().Be(test.seed);
+                IdentifiableSecrets.ComputeChecksumSeed(test.literal).Should().Be(test.seed);
             }
         }
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -21,7 +21,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.4.17");
+        version.ToString().Should().Be("1.4.18");
     }
 
     [TestMethod]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- NEW: Add `IdentifiableSecrets._ComputeChecksumSeed` to derive checksum seeds from versioned string literals, e.g., `ReadKey0`.

These literals must be 8 characters with at least one trailing digit.