### PR TITLE
Release/v1.4.19

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,7 @@
 - FNS => Flase negative reduction in static analysis.
 
 # 1.4.19 - 05/10/2024
-- NEW: Add `IIdenfitiableKey.EncodeForUrl` property for keys with URL-safe encodings. Also adds `IdentifiableKey` base class for shared 32-bit and 64-bit logic.
+- NEW: Add `IIdentifiableKey.EncodeForUrl` property for keys with URL-safe encodings. Also adds `IdentifiableKey` base class for shared 32-bit and 64-bit logic.
 - FNS: Correct length for `SEC101/166.AzureSearchIdentifiableQueryKey` and `SEC101/167.AzureSearchIdentifiableAdminKey`.
 
 # 1.4.18 - 05/10/2024

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -7,6 +7,12 @@
 - BUG => General bug fix.
 - NEW -> New API or feature.
 - PRF => Performance work.
+- FPS => False positive reduction in static analysis.
+- FNS => Flase negative reduction in static analysis.
+
+# 1.4.19 - 05/10/2024
+- NEW: Add `IIdenfitiableKey.EncodeForUrl` property for keys with URL-safe encodings. Also adds `IdentifiableKey` base class for shared 32-bit and 64-bit logic.
+- FNS: Correct length for `SEC101/166.AzureSearchIdentifiableQueryKey` and `SEC101/167.AzureSearchIdentifiableAdminKey`.
 
 # 1.4.18 - 05/10/2024
 - NEW: Add `IdentifiableSecrets.ComputeHisV1ChecksumSeed` to derive checksum seeds from versioned string literals, e.g., `ReadKey0`.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,10 @@
 - FNS => Flase negative reduction in static analysis.
 
 # 1.4.19 - 05/10/2024
+- BRK: Eliminate `Identifiable.TryValidateCommonAnnotatedKey` `checksum` and `customerManagedKey` parameters. Checksums now not configurable for HIS v2.
+- BRK: Eliminate `Identifiable.GenerateCommonAnnotated[Test]Key` `checksum` parameter.
 - NEW: Add `IIdentifiableKey.EncodeForUrl` property for keys with URL-safe encodings. Also adds `IdentifiableKey` base class for shared 32-bit and 64-bit logic.
+- NEW: Update `GenerateTestExamples` for standard keys to produce keys that are obviously test patterns due to character repetition, e.g., `cccccccccccccccccccccccccccccccccTESTCi1lAI=`.
 - FNS: Correct length for `SEC101/166.AzureSearchIdentifiableQueryKey` and `SEC101/167.AzureSearchIdentifiableAdminKey`.
 
 # 1.4.18 - 05/10/2024

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/Azure32ByteIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/Azure32ByteIdentifiableKey.cs
@@ -9,22 +9,8 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    public abstract class Azure32ByteIdentifiableKey : RegexPattern, IIdentifiableKey
+    public abstract class Azure32ByteIdentifiableKey : IdentifiableKey
     {
-        private ISet<string>? _sniffLiterals;
-
-        public Azure32ByteIdentifiableKey()
-        {
-            RotationPeriod = TimeSpan.FromDays(365 * 2);
-            DetectionMetadata = DetectionMetadata.Identifiable;
-        }
-
-        public abstract string Signature { get; }
-
-        public uint KeyLength => 32;
-
-        public abstract IEnumerable<ulong> ChecksumSeeds { get; }
-
         public string RegexNormalizedSignature => Signature.Replace("+", "\\+");
 
         public override string Pattern
@@ -32,43 +18,5 @@ namespace Microsoft.Security.Utilities
             get => @$"{WellKnownRegexPatterns.PrefixAllBase64}(?<refine>[{WellKnownRegexPatterns.Base64}]{{33}}{RegexNormalizedSignature}[A-P][{WellKnownRegexPatterns.Base64}]{{5}}=){WellKnownRegexPatterns.SuffixAllBase64}";
             protected set => base.Pattern = value;
         }
-        public override ISet<string>? SniffLiterals
-        {
-            get
-            {
-                _sniffLiterals ??= new HashSet<string>(new[] { Signature });
-                return _sniffLiterals;
-            }
-
-            protected set => _sniffLiterals = value;
-        }
-
-        public override Tuple<string, string>? GetMatchIdAndName(string match)
-        {
-            foreach (ulong checksumSeed in ChecksumSeeds)
-            {
-                if (IdentifiableSecrets.ValidateBase64Key(match,
-                                                          checksumSeed,
-                                                          Signature))
-                {
-                    return new Tuple<string, string>(Id, Name);
-                }
-            }
-
-            return null;
-        }
-
-        public override IEnumerable<string> GenerateTestExamples()
-        {
-            foreach (ulong checksumSeed in ChecksumSeeds)
-            {
-                yield return
-                    IdentifiableSecrets.GenerateStandardBase64Key(checksumSeed,
-                                                                  keyLengthInBytes: KeyLength,
-                                                                  Signature);
-            }
-        }
-
-        private const string TerminalCharactersFor64ByteKey = "AQgw";
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/Azure64ByteIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/Azure64ByteIdentifiableKey.cs
@@ -9,67 +9,16 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    public abstract class Azure64ByteIdentifiableKey : RegexPattern, IIdentifiableKey
+    public abstract class Azure64ByteIdentifiableKey : IdentifiableKey
     {
-        private ISet<string>? _sniffLiterals;
-
-        public Azure64ByteIdentifiableKey()
-        {
-            RotationPeriod = TimeSpan.FromDays(365 * 2);
-            DetectionMetadata = DetectionMetadata.Identifiable;
-        }
-
-        public abstract string Signature { get; }
-
-        public uint KeyLength => 64;
-
-        public abstract IEnumerable<ulong> ChecksumSeeds { get; }
-
         public string RegexNormalizedSignature => Signature.Replace("+", "\\+");
+
+        public override uint KeyLength => 64;
 
         public override string Pattern
         {
             get => $@"{WellKnownRegexPatterns.PrefixAllBase64}(?<refine>[{WellKnownRegexPatterns.Base64}]{{76}}{RegexNormalizedSignature}[{WellKnownRegexPatterns.Base64}]{{5}}[AQgw]==){WellKnownRegexPatterns.SuffixAllBase64}";
             protected set => base.Pattern = value;
         }
-
-        public override ISet<string>? SniffLiterals
-        {
-            get
-            {
-                _sniffLiterals ??= new HashSet<string>(new[] { Signature });
-                return _sniffLiterals;
-            }
-
-            protected set => _sniffLiterals = value;
-        }
-
-        public override Tuple<string, string>? GetMatchIdAndName(string match)
-        {
-            foreach (ulong checksumSeed in ChecksumSeeds)
-            {
-                if (IdentifiableSecrets.ValidateBase64Key(match,
-                                                          checksumSeed,
-                                                          Signature))
-                {
-                    return new Tuple<string, string>(Id, Name);
-                }
-            }
-
-            return null;
-        }
-
-        public override IEnumerable<string> GenerateTestExamples()
-        {
-            foreach (ulong checksumSeed in ChecksumSeeds)
-            {
-                yield return
-                    IdentifiableSecrets.GenerateStandardBase64Key(checksumSeed,
-                                                                  keyLengthInBytes: 64,
-                                                                  Signature);
-            }
-        }
-
-        private const string TerminalCharactersFor64ByteKey = "AQgw";
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/IIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/IIdentifiableKey.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Security.Utilities
         public string Signature { get; }
 
         public uint KeyLength { get; }
+        
+        public bool EncodeForUrl { get; }
 
         public IEnumerable<ulong> ChecksumSeeds { get; }
     }

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/IdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/IdentifiableKey.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Security.Utilities
+{
+    public abstract class IdentifiableKey : RegexPattern, IIdentifiableKey
+    {
+        private ISet<string>? _sniffLiterals;
+
+        public IdentifiableKey()
+        {
+            RotationPeriod = TimeSpan.FromDays(365 * 2);
+            DetectionMetadata = DetectionMetadata.Identifiable;
+        }
+
+        public abstract string Signature { get; }
+
+        public virtual uint KeyLength => 32;
+
+        public virtual bool EncodeForUrl => false;
+
+        public abstract IEnumerable<ulong> ChecksumSeeds { get; }
+
+        public override Tuple<string, string>? GetMatchIdAndName(string match)
+        {
+            foreach (ulong checksumSeed in ChecksumSeeds)
+            {
+                if (IdentifiableSecrets.ValidateBase64Key(match,
+                                                          checksumSeed,
+                                                          Signature))
+                {
+                    return new Tuple<string, string>(Id, Name);
+                }
+            }
+
+            return null;
+        }
+
+        public override ISet<string>? SniffLiterals
+        {
+            get
+            {
+                _sniffLiterals ??= new HashSet<string>(new[] { Signature });
+                return _sniffLiterals;
+            }
+
+            protected set => _sniffLiterals = value;
+        }
+
+        public override IEnumerable<string> GenerateTestExamples()
+        {
+            foreach (ulong checksumSeed in ChecksumSeeds)
+            {
+                string alphabet = EncodeForUrl ? WellKnownRegexPatterns.UrlSafeBase64 : WellKnownRegexPatterns.Base64;
+
+                for (int i = 0; i < 5; i++)
+                {
+                    byte[] bytes = new byte[KeyLength];
+                    int encodedLength = Convert.ToBase64String(bytes).Length;
+                    string encoded = new string(alphabet[i], encodedLength);
+                    Array.Copy(Convert.FromBase64String(encoded), bytes, KeyLength);
+
+                    yield return
+                        IdentifiableSecrets.GenerateBase64KeyHelper(checksumSeed,
+                                                                    keyLengthInBytes: KeyLength,
+                                                                    Signature,
+                                                                    EncodeForUrl,
+                                                                    bytes);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_166_AzureSearchIdentifiableQueryKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_166_AzureSearchIdentifiableQueryKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    internal class AzureSearchIdentifiableQueryKey : RegexPattern, IIdentifiableKey
+    internal class AzureSearchIdentifiableQueryKey : IdentifiableKey
     {
         public AzureSearchIdentifiableQueryKey()
         {
@@ -13,9 +13,9 @@ namespace Microsoft.Security.Utilities
             Name = nameof(AzureSearchIdentifiableQueryKey);
         }
 
-        public string Signature => IdentifiableMetadata.AzureSearchSignature;
+        override public string Signature => IdentifiableMetadata.AzureSearchSignature;
 
-        public virtual IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableMetadata.AzureSearchQueryKeyChecksumSeed };
+        override public IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableMetadata.AzureSearchQueryKeyChecksumSeed };
 
         public override string Pattern
         {
@@ -23,6 +23,6 @@ namespace Microsoft.Security.Utilities
             protected set => base.Pattern = value;
         }
 
-        public uint KeyLength => 52;
+        override public uint KeyLength => 39;
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Security.Utilities;
 /// </summary>
 public static class IdentifiableSecrets
 {
+    public static readonly ulong VersionTwoChecksumSeed = ComputeHisV1ChecksumSeed("Default0");
+
     public const string CommonAnnotatedKeyRegexPattern = "[A-Za-z0-9]{52}JQQJ99[A-Za-z0-9][A-L][A-Za-z0-9]{16}[A-Za-z][A-Za-z0-9]{7}([A-Za-z0-9]{2}==)?";
 
     public static readonly Regex CommonAnnotatedKeyRegex = new(CommonAnnotatedKeyRegexPattern, RegexDefaults.DefaultOptionsCaseSensitive);
@@ -47,13 +49,9 @@ public static class IdentifiableSecrets
     }
 
     public static bool TryValidateCommonAnnotatedKey(string key,
-                                                     ulong checksumSeed,
-                                                     string base64EncodedSignature,
-                                                     bool customerManagedKey)
+                                                     string base64EncodedSignature)
     {
-        base64EncodedSignature = customerManagedKey
-                ? base64EncodedSignature.ToUpperInvariant()
-                : base64EncodedSignature.ToLowerInvariant();
+        ulong checksumSeed = VersionTwoChecksumSeed;
 
         string componentToChecksum = key.Substring(0, key.Length - 4);
         string checksumText = key.Substring(key.Length - 4);
@@ -112,26 +110,26 @@ public static class IdentifiableSecrets
     }
 
 
-    public static string GenerateCommonAnnotatedKey(ulong checksumSeed,
-                                                    string base64EncodedSignature,
+    public static string GenerateCommonAnnotatedKey(string base64EncodedSignature,
                                                     bool customerManagedKey,
                                                     byte[] platformReserved,
-                                                    byte[] providerReserved)
+                                                    byte[] providerReserved,
+                                                    char? testChar = null)
     {
-        return GenerateCommonAnnotatedTestKey(checksumSeed,
+        return GenerateCommonAnnotatedTestKey(VersionTwoChecksumSeed,
                                               base64EncodedSignature,
                                               customerManagedKey,
                                               platformReserved,
                                               providerReserved,
-                                              testChar: null);
+                                              testChar);
     }
 
     public static string GenerateCommonAnnotatedTestKey(ulong checksumSeed,
-                                                    string base64EncodedSignature,
-                                                    bool customerManagedKey,
-                                                    byte[] platformReserved,
-                                                    byte[] providerReserved,
-                                                    char? testChar)
+                                                        string base64EncodedSignature,
+                                                        bool customerManagedKey,
+                                                        byte[] platformReserved,
+                                                        byte[] providerReserved,
+                                                        char? testChar)
     {
         const int platformReservedLength = 9; 
         const int providerReservedLength = 3;

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -136,7 +136,6 @@ namespace Microsoft.Security.Utilities
                 {
                     for (byte k = 0; k < iterations; k++)
                     {
-                        ulong checksumSeed = (ulong)Guid.NewGuid().ToString().GetHashCode();
                         string signature = Guid.NewGuid().ToString("N").Substring(0, 4);
 
                         signature = $"{alphabet[(int)keysGenerated % alphabet.Length]}{ signature.Substring(1)}";
@@ -179,8 +178,7 @@ namespace Microsoft.Security.Utilities
 
                         foreach (bool customerManaged in new[] { true, false })
                         {
-                            string key = IdentifiableSecrets.GenerateCommonAnnotatedKey(checksumSeed,
-                                                                                        signature,
+                            string key = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature,
                                                                                         customerManaged,
                                                                                         platformReserved, 
                                                                                         providerReserved);
@@ -188,7 +186,7 @@ namespace Microsoft.Security.Utilities
                             bool result = IdentifiableSecrets.CommonAnnotatedKeyRegex.IsMatch(key);
                             result.Should().BeTrue(because: $"the key '{key}' should match the common annotated key regex");
 
-                            result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, checksumSeed, signature, customerManaged);
+                            result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, signature);
                             result.Should().BeTrue(because: $"the key '{key}' should comprise an HIS v2-conformant pattern");
 
                             keysGenerated++;

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -20,7 +20,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.4.18");
+        version.ToString().Should().Be("1.4.19");
     }
 
     [TestMethod]

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -68,7 +68,7 @@ public class SecretMaskerTests
                             string context = testExample;
                             string standaloneSecret = CachedDotNetRegex.Instance.Matches(context, pattern.Pattern, captureGroup: "refine").First().Value;
 
-                            string moniker = pattern.GetMatchMoniker(context);
+                            string moniker = pattern.GetMatchMoniker(standaloneSecret);
 
                             // 1. All generated test patterns should be detected by the masker.
                             var detections = secretMasker.DetectSecrets(context);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- NEW: Add `IIdentifiableKey.EncodeForUrl` property for keys with URL-safe encodings. Also adds `IdentifiableKey` base class for shared 32-bit and 64-bit logic.
- FNS: Correct length for `SEC101/166.AzureSearchIdentifiableQueryKey` and `SEC101/167.AzureSearchIdentifiableAdminKey`.
