### PR TITLE
Add new scan types and fix UTF16 trailing byte case

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
@@ -21,7 +21,11 @@ public class IdentifiableScan: IDisposable
         U64Utf16 = 4,
         Utf8 = 5,
         Utf16 = 6,
-        Unknown = 7,
+        U39Utf8 = 7,
+        U39Utf16 = 8,
+        U40Utf8 = 9,
+        U40Utf16 = 10,
+        Unknown = 11,
     }
 
     [DllImport("microsoft_security_utilities_core")]

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
@@ -25,7 +25,11 @@ public class IdentifiableScan: IDisposable
         U39Utf16 = 8,
         U40Utf8 = 9,
         U40Utf16 = 10,
-        Unknown = 11,
+        A7Utf8 = 11,
+        A7Utf16 = 12,
+        A8Utf8 = 13,
+        A8Utf16 = 14,
+        Unknown = 15,
     }
 
     [DllImport("microsoft_security_utilities_core")]

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -486,8 +486,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::His32Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -511,8 +511,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::His64Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -552,8 +552,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::His39Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -593,8 +593,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::His40Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -634,8 +634,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::HisA7Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -675,8 +675,8 @@ impl PossibleScanMatch {
                     ScanMatch::new(
                         ScanMatchType::HisA8Utf16,
                         start,
-                        (count * 2) as u64,
-                        &bytes[0..count],
+                        (len * 2) as u64,
+                        &bytes[0..len],
                         want_text))
             },
 
@@ -1379,6 +1379,9 @@ mod tests {
         cases.push(Case::new(
             "zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
             "zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
+        cases.push(Case::new(
+            "zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzZZZ",
+            "zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
 
         /* 32-byte cases */
         cases.push(Case::new(
@@ -1408,6 +1411,12 @@ mod tests {
         cases.push(Case::new(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng=",
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng="));
+        cases.push(Case::new(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng=ZZZZ",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng="));
+        cases.push(Case::new(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbngZZZZ",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng"));
 
         /* 39-byte cases */
         cases.push(Case::new(
@@ -1419,6 +1428,9 @@ mod tests {
         cases.push(Case::new(
             "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQE",
             "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQE"));
+        cases.push(Case::new(
+            "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQEZZZZZ",
+            "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQE"));
 
         /* 40-byte cases */
         cases.push(Case::new(
@@ -1427,6 +1439,9 @@ mod tests {
         cases.push(Case::new(
             "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA==",
             "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA=="));
+        cases.push(Case::new(
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhAZZZZZ",
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA"));
 
         /* 64-byte cases */
         cases.push(Case::new(
@@ -1444,6 +1459,12 @@ mod tests {
         cases.push(Case::new(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ==",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ==ZZZZZ",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQZZZZZ",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ"));
 
         for (i, case) in cases.iter().enumerate() {
             let match_str = case.expected;

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -9,9 +9,13 @@ const HIS2_UTF16_SHORT_LEN: usize = HIS2_UTF8_SHORT_LEN * 2;
 const HIS2_UTF16_SHORT_LEN_BE: usize = HIS2_UTF16_SHORT_LEN - 1;
 
 const HIS_32_UTF8_LEN: usize = 44;
+const HIS_39_UTF8_LEN: usize = 53;
+const HIS_40_UTF8_LEN: usize = 56;
 const HIS_64_UTF8_LEN: usize = 88;
 
 const HIS_32_UTF16_LEN: usize = HIS_32_UTF8_LEN * 2;
+const HIS_39_UTF16_LEN: usize = HIS_39_UTF8_LEN * 2;
+const HIS_40_UTF16_LEN: usize = HIS_40_UTF8_LEN * 2;
 const HIS_64_UTF16_LEN: usize = HIS_64_UTF8_LEN * 2;
 
 trait Base64 {
@@ -40,6 +44,10 @@ pub enum ScanMatchType {
     His64Utf16 = 4,
     His2Utf8 = 5,
     His2Utf16 = 6,
+    His39Utf8 = 7,
+    His39Utf16 = 8,
+    His40Utf8 = 9,
+    His40Utf16 = 10,
 }
 
 pub struct ScanMatch {
@@ -110,10 +118,85 @@ impl PossibleScanMatch {
             ScanMatchType::His32Utf16 => { HIS_32_UTF16_LEN },
             ScanMatchType::His64Utf8 => { HIS_64_UTF8_LEN },
             ScanMatchType::His64Utf16 => { HIS_64_UTF16_LEN },
+            ScanMatchType::His39Utf8 => { HIS_39_UTF8_LEN },
+            ScanMatchType::His39Utf16 => { HIS_39_UTF16_LEN },
+            ScanMatchType::His40Utf8 => { HIS_40_UTF8_LEN },
+            ScanMatchType::His40Utf16 => { HIS_40_UTF16_LEN },
         }
     }
 
     pub fn match_type(&self) -> &ScanMatchType { &self.mtype }
+
+    fn his_39_matched_bytes(data: &[u8]) -> usize {
+        /*
+         * 42 Base64 + 4 signature + 1 [A-D] + 5 Base64 + optional 1 [=]
+         */
+        if data.len() < 52 {
+            return 0;
+        }
+
+        for b in &data[0..42] {
+            if !b.is_base64() {
+                return 0;
+            }
+        }
+
+        /* NOTE: We skip the signature since we already checked */
+
+        if data[46] < b'A' || data[46] > b'D' {
+            return 0;
+        }
+
+        for b in &data[47..52] {
+            if !b.is_base64() {
+                return 0;
+            }
+        }
+
+        if data.len() >= HIS_39_UTF8_LEN {
+            if data[52] == b'=' {
+                return HIS_39_UTF8_LEN;
+            }
+        }
+
+        52
+    }
+
+    fn his_40_matched_bytes(data: &[u8]) -> usize {
+        /*
+         * 44 Base64 + 4 signature + 5 Base64 + [AOgw] + optional 2 [=]
+         */
+        if data.len() < 54 {
+            return 0;
+        }
+
+        for b in &data[0..44] {
+            if !b.is_base64() {
+                return 0;
+            }
+        }
+
+        /* NOTE: We skip the signature since we already checked */
+
+        for b in &data[48..53] {
+            if !b.is_base64() {
+                return 0;
+            }
+        }
+
+        match data[53] {
+            b'A' | b'O' | b'g' | b'w' => { },
+            _ => { return 0; },
+        }
+
+        if data.len() >= HIS_40_UTF8_LEN {
+            if data[54] == b'=' && data[55] == b'=' {
+                return HIS_40_UTF8_LEN;
+            }
+        }
+
+        54
+    }
 
     fn his_32_matched_bytes(data: &[u8]) -> usize {
         /*
@@ -331,7 +414,7 @@ impl PossibleScanMatch {
 
                 Some(
                     ScanMatch::new(
-                        ScanMatchType::His32Utf8,
+                        ScanMatchType::His32Utf16,
                         start,
                         (count * 2) as u64,
                         &bytes[0..count],
@@ -356,7 +439,89 @@ impl PossibleScanMatch {
 
                 Some(
                     ScanMatch::new(
-                        ScanMatchType::His64Utf8,
+                        ScanMatchType::His64Utf16,
+                        start,
+                        (count * 2) as u64,
+                        &bytes[0..count],
+                        want_text))
+            },
+
+            ScanMatchType::His39Utf8 => {
+                let len = Self::his_39_matched_bytes(&data);
+
+                if len == 0 {
+                    return None;
+                }
+
+                Some(
+                    ScanMatch::new(
+                        ScanMatchType::His39Utf8,
+                        start,
+                        len as u64,
+                        &data[0..len],
+                        want_text))
+            },
+
+            ScanMatchType::His39Utf16 => {
+                let mut bytes: [u8; HIS_39_UTF8_LEN] = [0; HIS_39_UTF8_LEN];
+                let mut count = Self::convert_utf16(data, &mut bytes);
+
+                if data.len() & 1 == 1 {
+                    /* Add trailing unaligned byte edge case */
+                    bytes[count] = data[data.len()-1];
+                    count += 1;
+                }
+
+                let len = Self::his_39_matched_bytes(&bytes);
+
+                if len == 0 {
+                    return None;
+                }
+
+                Some(
+                    ScanMatch::new(
+                        ScanMatchType::His39Utf16,
+                        start,
+                        (count * 2) as u64,
+                        &bytes[0..count],
+                        want_text))
+            },
+
+            ScanMatchType::His40Utf8 => {
+                let len = Self::his_40_matched_bytes(&data);
+
+                if len == 0 {
+                    return None;
+                }
+
+                Some(
+                    ScanMatch::new(
+                        ScanMatchType::His40Utf8,
+                        start,
+                        len as u64,
+                        &data[0..len],
+                        want_text))
+            },
+
+            ScanMatchType::His40Utf16 => {
+                let mut bytes: [u8; HIS_40_UTF8_LEN] = [0; HIS_40_UTF8_LEN];
+                let mut count = Self::convert_utf16(data, &mut bytes);
+
+                if data.len() & 1 == 1 {
+                    /* Add trailing unaligned byte edge case */
+                    bytes[count] = data[data.len()-1];
+                    count += 1;
+                }
+
+                let len = Self::his_40_matched_bytes(&bytes);
+
+                if len == 0 {
+                    return None;
+                }
+
+                Some(
+                    ScanMatch::new(
+                        ScanMatchType::His40Utf16,
                         start,
                         (count * 2) as u64,
                         &bytes[0..count],
@@ -579,13 +744,43 @@ impl Scan {
                 /* +AEh */
                 0x2B414568 |
                 /* +ARm */
-                0x2B41526D => {
+                0x2B41526D |
+                /* AzCa */
+                0x417A4361 |
+                /* AZEG */
+                0x415A4547 => {
                     if self.index >= 37 {
                         /* Signature Detection */
                         self.checks.push(
                             PossibleScanMatch::new(
                                 self.index - 37,
                                 ScanMatchType::His32Utf8));
+                    }
+                },
+
+                /* 39-byte signatures */
+                /* AzSe */
+                0x417A5365 |
+                /* +ACR */
+                0x2B414352 => {
+                    if self.index >= 46 {
+                        /* Signature Detection */
+                        self.checks.push(
+                            PossibleScanMatch::new(
+                                self.index - 46,
+                                ScanMatchType::His39Utf8));
+                    }
+                },
+
+                /* 40-byte signatures */
+                /* AzFu */
+                0x417A4675 => {
+                    if self.index >= 48 {
+                        /* Signature Detection */
+                        self.checks.push(
+                            PossibleScanMatch::new(
+                                self.index - 48,
+                                ScanMatchType::His40Utf8));
                     }
                 },
 
@@ -625,13 +820,43 @@ impl Scan {
                 /* +AEh */
                 0x002B004100450068 |
                 /* +ARm */
-                0x002B00410052006D => {
+                0x002B00410052006D |
+                /* AzCa */
+                0x0041007A00430061 |
+                /* AZEG */
+                0x0041005A00450047 => {
                     if self.index >= 73 {
                         /* Signature Detection */
                         self.checks.push(
                             PossibleScanMatch::new(
                                 self.index - 73,
                                 ScanMatchType::His32Utf16));
+                    }
+                },
+
+                /* 39-byte signatures */
+                /* AzSe */
+                0x0041007A00530065 |
+                /* +ACR */
+                0x002B004100430052 => {
+                    if self.index >= 91 {
+                        /* Signature Detection */
+                        self.checks.push(
+                            PossibleScanMatch::new(
+                                self.index - 91,
+                                ScanMatchType::His39Utf16));
+                    }
+                },
+
+                /* 40-byte signatures */
+                /* AzFu */
+                0x0041007A00460075 => {
+                    if self.index >= 95 {
+                        /* Signature Detection */
+                        self.checks.push(
+                            PossibleScanMatch::new(
+                                self.index - 95,
+                                ScanMatchType::His40Utf16));
                     }
                 },
 
@@ -861,6 +1086,22 @@ impl Scan {
 mod tests {
     use super::*;
 
+    struct Case {
+        test: &'static str,
+        expected: &'static str,
+    }
+
+    impl Case {
+        fn new(
+            test: &'static str,
+            expected: &'static str) -> Self {
+            Self {
+                test,
+                expected,
+            }
+        }
+    }
+
     #[test]
     fn his_v2_scan_files() {
         let mut scan = Scan::new(ScanOptions::default());
@@ -908,30 +1149,73 @@ mod tests {
         let mut cases = Vec::new();
 
         /* 32-byte cases */
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo=");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w=");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI=");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco=");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco");
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo=",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w=",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI=",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco=",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ARmD7h+qo"));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+AEhG2s/8w"));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASbHpHeAI"));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAIoTOumzco"));
+        cases.push(Case::new(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng=",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbAZEGLiQbng="));
+
+        /* 39-byte cases */
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAzSeCjhzCu",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAzSeCjhzCu"));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAzSeCjhzCu=",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAzSeCjhzCu="));
+        cases.push(Case::new(
+            "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQE",
+            "dddddddddddddddddddddddddddddddddddddddddd+ACRCUDxQE"));
+
+        /* 40-byte cases */
+        cases.push(Case::new(
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA",
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA"));
+        cases.push(Case::new(
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA==",
+            "ddddddddddddddddddddddddddddddddddddddddddddAzFu182vhA=="));
 
         /* 64-byte cases */
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASt5mnCaw==");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaACDbOpqrYA==");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ABa13FZVQ==");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AM71lnmRw==");
-        cases.push("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ==");
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASt5mnCaw==",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ASt5mnCaw=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaACDbOpqrYA==",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaACDbOpqrYA=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ABa13FZVQ==",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+ABa13FZVQ=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AM71lnmRw==",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AM71lnmRw=="));
+        cases.push(Case::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ==",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAPIMHbKhsQ=="));
 
         for (i, case) in cases.iter().enumerate() {
-            let match_str = if case.len() > HIS_32_UTF8_LEN && case.len() < (HIS_64_UTF8_LEN - 2) {
-                &case[0..HIS_32_UTF8_LEN]
-            } else if case.len() > HIS_64_UTF8_LEN {
-                &case[0..HIS_64_UTF8_LEN]
-            }else {
-                &case[0..]
-            };
+            let match_str = case.expected;
+            let case = case.test;
 
             /* UTF8 */
             let data = case.as_bytes();


### PR DESCRIPTION
Add new 32, 39, and 40 byte signatures.
Add AAD signatures (7Q~ and 8Q~).
Fix UTF16 trailing byte case.