### PR TITLE
CASK derived keys. Fix HIS v1 derived keys.

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,10 @@
 - FNS => Flase negative reduction in static analysis.
 
 # 1.4.21 - 05/21/2024
+- BRK: Rename `IdentifiableSecrets.ComputeDerivedSymmetricKey` to `ComputeDerivedIdentifiableKey`.
+- BRK: Update `IdentifiableSecrets.ComputeDerivedIdentifiableKey` to accept an alternate checksum seed for constructing the derived key.
 - NEW: Add `CommonAnnotatedSecret` key class for next-generation identifiable secrets.
+- NEW: Add `Identifiable.ComputeDerivedCommonAnnotatedKey` to generate keys derived from common annotated secrets.
 
 # 1.4.20 - 05/16/2024
 - BRK: Add `ComputeHash32(byte[], ulong, int, int)` helper to bring .NET framework and .NET core APIs into alignment.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -10,6 +10,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => Flase negative reduction in static analysis.
 
+# 1.4.21 - 05/21/2024
+
+
 # 1.4.20 - 05/16/2024
 - BRK: Add `ComputeHash32(byte[], ulong, int, int)` helper to bring .NET framework and .NET core APIs into alignment.
 - BRK: Return value of `ISecretMaskerDetectSecrets(string)` is `IEnumerable<Detection>` (not `ICollection`) for best yield iterator compatibility.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,7 @@
 - FNS => Flase negative reduction in static analysis.
 
 # 1.4.21 - 05/21/2024
-
+- NEW: Add `CommonAnnotatedSecret` key class for next-generation identifiable secrets.
 
 # 1.4.20 - 05/16/2024
 - BRK: Add `ComputeHash32(byte[], ulong, int, int)` helper to bring .NET framework and .NET core APIs into alignment.

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -8,9 +8,9 @@ using System;
 
 namespace Microsoft.Security.Utilities
 {
-    public class CommonAnnotatedSecret
+    public class CommonAnnotatedKey
     {
-        public static bool TryCreate(string key, out CommonAnnotatedSecret secret)
+        public static bool TryCreate(string key, out CommonAnnotatedKey secret)
         {
             secret = null;
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
@@ -48,22 +48,13 @@ namespace Microsoft.Security.Utilities
                 key = Convert.ToBase64String(keyBytes);
             }
 
-            try
-            {
-                bool isValid = IdentifiableSecrets.ValidateBase64Key(key, checksumSeed, base64EncodedSignature);
-
-                if (!isValid)
-                {
-                    return false;
-                }
-            }
-            catch (FormatException)
+            if (!IdentifiableSecrets.TryValidateBase64Key(key, checksumSeed, base64EncodedSignature))
             {
                 return false;
             }
 
             byte[] bytes = Convert.FromBase64String(key);
-            secret = new CommonAnnotatedSecret(bytes);
+            secret = new CommonAnnotatedKey(bytes);
 
             return true;
         }
@@ -71,7 +62,7 @@ namespace Microsoft.Security.Utilities
         private byte[] bytes;
         private string base64Key;
 
-        private CommonAnnotatedSecret(byte[] bytes)
+        private CommonAnnotatedKey(byte[] bytes)
         {
             this.bytes = bytes;
             this.base64Key = Convert.ToBase64String(this.bytes);

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Security.Utilities
             secret = null;
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
             string base64EncodedSignature = key.Substring(76, 4);
-            bool isDerived = key[57] == 'D';
+            bool isDerived = key[DerivedKeyCharacterOffset] == 'D';
 
             if (key.Length != 88 && key.Length != 84)
             {
@@ -68,7 +68,9 @@ namespace Microsoft.Security.Utilities
             this.base64Key = Convert.ToBase64String(this.bytes);
         }
 
-        public bool IsDerivedKey => this.base64Key[57] == 'D';
+        public const int DerivedKeyCharacterOffset = 57;
+
+        public bool IsDerivedKey => this.base64Key[DerivedKeyCharacterOffset] == 'D';
 
         public bool IsLongFormKey => bytes.Length == 64;
 
@@ -79,13 +81,13 @@ namespace Microsoft.Security.Utilities
 
         public string DateText => this.base64Key.Substring(58, 2);
 
-        public DateTime CreationDate => ComputeDateTime(DateText);
-
         public string PlatformReserved => this.base64Key.Substring(60, 12);
 
         public string ProviderReserved => this.base64Key.Substring(72, 4);
 
         public string ProviderFixedSignature => this.base64Key.Substring(76, 4);
+
+        public DateTime CreationDate => ComputeDateTime(DateText);
 
         private static DateTime ComputeDateTime(string dateText)
         {

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+using Base62;
+
+using System;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Microsoft.Security.Utilities
+{
+    public class CommonAnnotatedKey
+    {
+        public static bool TryCreate(string key, out CommonAnnotatedKey secret)
+        {
+            secret = null;
+            ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
+            string base64EncodedSignature = key.Substring(76, 4);
+            bool isDerived = key[57] == 'D';
+
+            if (key.Length != 88 && key.Length != 84)
+            {
+                return false;
+            }
+
+            if (key.Length == 84)
+            {
+                string partialEncodedChecksum = key.Substring(key.Length - 4);
+
+                byte[] incomingKeyBytes = Convert.FromBase64String(key);
+                byte[] keyBytes = new byte[64];
+                Array.Copy(incomingKeyBytes, keyBytes, incomingKeyBytes.Length);
+
+                int checksum = Marvin.ComputeHash32(keyBytes, checksumSeed, 0, keyBytes.Length - 4);
+
+                byte[] checksumBytes = BitConverter.GetBytes(checksum);
+                string encodedChecksum = isDerived ? checksum.ToBase62() : Convert.ToBase64String(checksumBytes);
+
+                if (!encodedChecksum.StartsWith(partialEncodedChecksum))
+                {
+                    return false;
+                }
+
+                keyBytes[keyBytes.Length - 4] = checksumBytes[0];
+                keyBytes[keyBytes.Length - 3] = checksumBytes[1];
+                keyBytes[keyBytes.Length - 2] = checksumBytes[2];
+                keyBytes[keyBytes.Length - 1] = checksumBytes[3];
+                
+                key = Convert.ToBase64String(keyBytes);
+            }
+
+            try
+            {
+                bool isValid = IdentifiableSecrets.ValidateBase64Key(key, checksumSeed, base64EncodedSignature);
+
+                if (!isValid)
+                {
+                    return false;
+                }
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            byte[] bytes = Convert.FromBase64String(key);
+            secret = new CommonAnnotatedKey(bytes);
+
+            return true;
+        }
+
+        private byte[] bytes;
+        private string base64Key;
+
+        private CommonAnnotatedKey(byte[] bytes)
+        {
+            this.bytes = bytes;
+            this.base64Key = Convert.ToBase64String(this.bytes);
+        }
+
+        public bool IsDerivedKey => this.base64Key[57] == 'D';
+
+        public bool IsLongFormKey => bytes.Length == 64;
+
+        // 123456789012345678901234567890123456789012345678901234567890123456789012345678901234[5678]
+        // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaJQQJ99ADccrrrrrtttttppppASIGixi1[xx==]
+
+        public string StandardFixedSignature => this.base64Key.Substring(52, 6);
+
+        public string DateText => this.base64Key.Substring(58, 2);
+
+        public string PlatformReserved => this.base64Key.Substring(60, 12);
+
+        public string ProviderReserved => this.base64Key.Substring(72, 4);
+
+        public string ProviderFixedSignature => this.base64Key.Substring(76, 4);
+    }
+}

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedSecret.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedSecret.cs
@@ -8,9 +8,9 @@ using System;
 
 namespace Microsoft.Security.Utilities
 {
-    public class CommonAnnotatedKey
+    public class CommonAnnotatedSecret
     {
-        public static bool TryCreate(string key, out CommonAnnotatedKey secret)
+        public static bool TryCreate(string key, out CommonAnnotatedSecret secret)
         {
             secret = null;
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
@@ -63,7 +63,7 @@ namespace Microsoft.Security.Utilities
             }
 
             byte[] bytes = Convert.FromBase64String(key);
-            secret = new CommonAnnotatedKey(bytes);
+            secret = new CommonAnnotatedSecret(bytes);
 
             return true;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Security.Utilities
         private byte[] bytes;
         private string base64Key;
 
-        private CommonAnnotatedKey(byte[] bytes)
+        private CommonAnnotatedSecret(byte[] bytes)
         {
             this.bytes = bytes;
             this.base64Key = Convert.ToBase64String(this.bytes);
@@ -88,10 +88,25 @@ namespace Microsoft.Security.Utilities
 
         public string DateText => this.base64Key.Substring(58, 2);
 
+        public DateTime CreationDate => ComputeDateTime(DateText);
+
         public string PlatformReserved => this.base64Key.Substring(60, 12);
 
         public string ProviderReserved => this.base64Key.Substring(72, 4);
 
         public string ProviderFixedSignature => this.base64Key.Substring(76, 4);
+
+        private static DateTime ComputeDateTime(string dateText)
+        {
+            if (dateText.Length != 2)
+            {
+                throw new ArgumentException("Invalid date text", nameof(dateText));
+            }
+
+            int year = 2024 + dateText[0] - 'A';
+            int month = dateText[1] - 'A' + 1;
+
+            return new DateTime(year, month, 1);
+        }
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -112,7 +112,7 @@ public static class IdentifiableSecrets
     public static string ComputeDerivedCommonAnnotatedKey(string key,
                                                           string hashSecret)
     {
-        if (!CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask))
+        if (!CommonAnnotatedSecret.TryCreate(key, out CommonAnnotatedSecret cask))
         { 
             throw new ArgumentException("The provided key is not a valid common annotated security key.");
         }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -112,7 +112,7 @@ public static class IdentifiableSecrets
     public static string ComputeDerivedCommonAnnotatedKey(string key,
                                                           string hashSecret)
     {
-        if (!CommonAnnotatedSecret.TryCreate(key, out CommonAnnotatedSecret cask))
+        if (!CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask))
         { 
             throw new ArgumentException("The provided key is not a valid common annotated security key.");
         }

--- a/src/Microsoft.Security.Utilities.sln
+++ b/src/Microsoft.Security.Utilities.sln
@@ -27,7 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Security.Utilities.Cli", "Microsoft.Security.Utilities.Cli\Microsoft.Security.Utilities.Cli.csproj", "{435A69E1-DE63-4B02-95D4-EE73CA4A5DC2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Security.Utilities.Benchmarks", "Benchmarks\Microsoft.Security.Utilities.Benchmarks.csproj", "{0B1DDF4F-4D23-454C-A469-284D60EA265A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Security.Utilities.Benchmarks", "Microsoft.Security.Utilities.Benchmarks\Microsoft.Security.Utilities.Benchmarks.csproj", "{58337536-C935-47D8-A3B3-5336D7143FD9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,10 +47,10 @@ Global
 		{435A69E1-DE63-4B02-95D4-EE73CA4A5DC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{435A69E1-DE63-4B02-95D4-EE73CA4A5DC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{435A69E1-DE63-4B02-95D4-EE73CA4A5DC2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0B1DDF4F-4D23-454C-A469-284D60EA265A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B1DDF4F-4D23-454C-A469-284D60EA265A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0B1DDF4F-4D23-454C-A469-284D60EA265A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B1DDF4F-4D23-454C-A469-284D60EA265A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58337536-C935-47D8-A3B3-5336D7143FD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58337536-C935-47D8-A3B3-5336D7143FD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58337536-C935-47D8-A3B3-5336D7143FD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58337536-C935-47D8-A3B3-5336D7143FD9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Security.Utilities
 
                     string derivedKey = IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey(key, hashingSecret);
 
-                    bool result = CommonAnnotatedKey.TryCreate(derivedKey, out CommonAnnotatedKey caKey);
+                    bool result = CommonAnnotatedSecret.TryCreate(derivedKey, out CommonAnnotatedSecret caKey);
                     result.Should().BeTrue(because: $"the derived key '{derivedKey}' should be a valid common annotated security key");
 
                     caKey.IsDerivedKey.Should().BeTrue(because: $"the derived key '{derivedKey}' 'IsDerived' property should be correct");
@@ -98,6 +98,10 @@ namespace Microsoft.Security.Utilities
 
                     result = IdentifiableSecrets.CommonAnnotatedKeyRegex.IsMatch(derivedKey);
                     result.Should().BeTrue(because: $"the derived key '{derivedKey}' should match the canonical format regex");
+
+                    DateTime utcNow = DateTime.UtcNow;
+                    caKey.CreationDate.Year.Should().Be(utcNow.Year, because: "the derived key creation year should be correct");
+                    caKey.CreationDate.Month.Should().Be(utcNow.Month, because: "the derived key creation month should be correct");
                 }
             }
         }

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Security.Utilities
 
                     string derivedKey = IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey(key, hashingSecret);
 
-                    bool result = CommonAnnotatedSecret.TryCreate(derivedKey, out CommonAnnotatedSecret caKey);
+                    bool result = CommonAnnotatedKey.TryCreate(derivedKey, out CommonAnnotatedKey caKey);
                     result.Should().BeTrue(because: $"the derived key '{derivedKey}' should be a valid common annotated security key");
 
                     caKey.IsDerivedKey.Should().BeTrue(because: $"the derived key '{derivedKey}' 'IsDerived' property should be correct");

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -40,16 +40,16 @@ namespace Microsoft.Security.Utilities
                                                                             IdentifiableMetadata.AzureIotSignature);
 
             string shortDerivedKey = IdentifiableSecrets.ComputeDerivedIdentifiableKey(shortKey,
-                                                                                    "SecretPlacehoder",
-                                                                                    IdentifiableMetadata.AzureIotDeviceChecksumSeed);
+                                                                                       "SecretPlacehoder",
+                                                                                       IdentifiableMetadata.AzureIotDeviceChecksumSeed);
 
             string longKey = IdentifiableSecrets.GenerateStandardBase64Key(IdentifiableMetadata.AzureIotDeviceChecksumSeed,
                                                                            64,
                                                                            IdentifiableMetadata.AzureIotSignature);
 
             string longDerivedKey = IdentifiableSecrets.ComputeDerivedIdentifiableKey(longKey,
-                                                                                   "SecretPlacehoder",
-                                                                                   IdentifiableMetadata.AzureIotDeviceChecksumSeed);
+                                                                                      "SecretPlacehoder",
+                                                                                      IdentifiableMetadata.AzureIotDeviceChecksumSeed);
 
             foreach (string key in new[] {shortKey, shortDerivedKey, longKey, longDerivedKey}) 
             { 

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -20,7 +20,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.4.20");
+        version.ToString().Should().Be("1.4.21");
     }
 
     [TestMethod]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- BRK: Rename `IdentifiableSecrets.ComputeDerivedSymmetricKey` to `ComputeDerivedIdentifiableKey`.
- BRK: Update `IdentifiableSecrets.ComputeDerivedIdentifiableKey` to accept an alternate checksum seed for constructing the derived key.
- NEW: Add `CommonAnnotatedSecret` key class for next-generation identifiable secrets.
- NEW: Add `Identifiable.ComputeDerivedCommonAnnotatedKey` to generate keys derived from common annotated secrets.

This change adds a new derived key API that is fully conformant with the next-generation common annotated security key standard, as well as a base class to instantiate and deconstruct individual elements of a `CommonAnnotatedSecret`.

This change additionally updates the older `identifiable` derived key computation to allow for the derived key checksum to diverge from the checksum of the parent key. 