### PR TITLE
Correct `AzureCosmosDBIdentifiableKey` rule id

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -10,6 +10,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => Flase negative reduction in static analysis.
 
+# UNRELEASED
+- BUG: Correct `AzureCosmosDBIdentifiableKey` rule id to `SEC101/160` (previously incorrectly listed as `SEC101/163`).
+
 # 1.4.22 - 05/21/2024
 - BUG: Fix `IdentifiableSecrets.ComputeDerivedSymmetricKey` and `IdentifiableSecrets.ComputeDerivedIdentifiableKey` to properly initialize the `HMACSHA256` algorithm with the cask/identifiable secret.
 

--- a/src/Microsoft.Security.Utilities.Benchmarks/RegexEngineDetectionBenchmarks.cs
+++ b/src/Microsoft.Security.Utilities.Benchmarks/RegexEngineDetectionBenchmarks.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Security.Utilities.Benchmarks
     public class RegexEngineDetectionBenchmarks
     {
         // The # of iterations of the scan to run.
-        private const int s_iterations = 10;
+        protected const int s_iterations = 100;
 
         // The size of randomized data to add as a prefix
         // for every secret. This is intended to make positive
         // hit less concentrated in the profiling.
-        private const int secretPrefixSize = 1000 * 1024;
+        private const int secretPrefixSize = 100 * 1024;
 
-        private static readonly string prefix = GenerateRandomData(secretPrefixSize);
+        public static readonly string ScanContentPrefix = GenerateRandomData(secretPrefixSize);
 
         private static string GenerateRandomData(int size)
         {
@@ -30,19 +30,39 @@ namespace Microsoft.Security.Utilities.Benchmarks
         // production overhead to all the scanners.
         private const bool s_generateCorrelatingIds = false;
 
-        private static IEnumerable<RegexPattern> RegexPatterns()
+        public static IEnumerable<RegexPattern> RegexPatterns()
         {
-            foreach (RegexPattern regexPattern in WellKnownRegexPatterns.HighConfidenceSecurityModels)
-            {
-                if  (regexPattern is Azure32ByteIdentifiableKey ||
-                     regexPattern is Azure64ByteIdentifiableKey)
-                {
-                    yield return regexPattern;
-                }
-
-                yield return WellKnownRegexPatterns.AadClientAppIdentifiableCredentialsCurrent();
-                yield return WellKnownRegexPatterns.AadClientAppIdentifiableCredentialsPrevious();
-            }
+            yield return WellKnownRegexPatterns.AadClientAppIdentifiableCredentialsCurrent();
+            yield return WellKnownRegexPatterns.AadClientAppIdentifiableCredentialsPrevious();
+            yield return new AzureFunctionIdentifiableKey();
+            yield return new AzureSearchIdentifiableQueryKey();
+            yield return new AzureSearchIdentifiableAdminKey();
+            yield return new AzureRelayIdentifiableKey();
+            yield return new AzureEventHubIdentifiableKey();
+            yield return new AzureServiceBusIdentifiableKey();
+            yield return new AzureIotHubIdentifiableKey();
+            yield return new AzureIotDeviceIdentifiableKey();
+            yield return new AzureIotDeviceProvisioningIdentifiableKey();
+            yield return new AzureStorageAccountIdentifiableKey();
+            yield return new AzureCosmosDBIdentifiableKey();
+            yield return new AzureBatchIdentifiableKey();
+            yield return new AzureMLWebServiceClassicIdentifiableKey();
+            yield return new AzureApimIdentifiableDirectManagementKey();
+            yield return new AzureApimIdentifiableSubscriptionKey();
+            yield return new AzureApimIdentifiableGatewayKey();
+            yield return new AzureApimIdentifiableRepositoryKey();
+            yield return new AzureCacheForRedisIdentifiableKey();
+            yield return new AzureContainerRegistryIdentifiableKey();
+//            yield return new SecretScanningSampleToken();
+//            yield return WellKnownRegexPatterns.NuGetApiKey();
+//            yield return new AadClientAppLegacyCredentials32();      // SEC101/101
+//            yield return new AadClientAppLegacyCredentials34();      // SEC101/101
+//            yield return new AdoPat();                               // SEC101/102
+//            yield return new AzureCosmosDBLegacyCredentials();       // SEC101/104
+//            yield return new AzureStorageAccountLegacyCredentials(); // SEC101/106
+//            yield return new AzureMessageLegacyCredentials();
+//            yield return new AzureDatabricksPat();
+//            yield return new AzureEventGridIdentifiableKey();
         }
 
         [Benchmark]
@@ -90,7 +110,7 @@ namespace Microsoft.Security.Utilities.Benchmarks
                         localCount++;
 
                         // Demonstrate classification/detection only.
-                        int count = masker.DetectSecrets($"{prefix} {example}").Count();
+                        int count = masker.DetectSecrets($"{ScanContentPrefix} {example}").Count();
 
                         if (count == 0)
                         {

--- a/src/Microsoft.Security.Utilities.Benchmarks/RegexEngineDetectionBenchmarks.cs
+++ b/src/Microsoft.Security.Utilities.Benchmarks/RegexEngineDetectionBenchmarks.cs
@@ -53,6 +53,10 @@ namespace Microsoft.Security.Utilities.Benchmarks
             yield return new AzureApimIdentifiableRepositoryKey();
             yield return new AzureCacheForRedisIdentifiableKey();
             yield return new AzureContainerRegistryIdentifiableKey();
+// There are all candidate rules that could be considered for the lower-level library.
+// Some are obviously feasible to add, others could entail novel detection techniques
+// that may or may not be implemented. Most of the less feasible detections are for
+// locating obsoleted key formats.
 //            yield return new SecretScanningSampleToken();
 //            yield return WellKnownRegexPatterns.NuGetApiKey();
 //            yield return new AadClientAppLegacyCredentials32();      // SEC101/101

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_158_AzureFunctionIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_158_AzureFunctionIdentifiableKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    internal class AzureFunctionIdentifiableKey : IdentifiableKey
+    public class AzureFunctionIdentifiableKey : IdentifiableKey
     {
         public AzureFunctionIdentifiableKey()
         {

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_160_AzureCosmosDbIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_160_AzureCosmosDbIdentifiableKey.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Security.Utilities
     {
         public AzureCosmosDBIdentifiableKey()
         {
-            Id = "SEC101/163";
+            Id = "SEC101/160";
             Name = nameof(AzureCosmosDBIdentifiableKey);
         }
 

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_166_AzureSearchIdentifiableQueryKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_166_AzureSearchIdentifiableQueryKey.cs
@@ -13,16 +13,27 @@ namespace Microsoft.Security.Utilities
             Name = nameof(AzureSearchIdentifiableQueryKey);
         }
 
+        public override bool EncodeForUrl => true;
+
         override public string Signature => IdentifiableMetadata.AzureSearchSignature;
 
         override public IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableMetadata.AzureSearchQueryKeyChecksumSeed };
 
         public override string Pattern
         {
-            get => @$"{WellKnownRegexPatterns.PrefixAllBase64}(?<refine>[{WellKnownRegexPatterns.Base64}]{{42}}{Signature}[A-D][{WellKnownRegexPatterns.Base64}]{{5}}){WellKnownRegexPatterns.SuffixAllBase64}";
+            get => @$"{WellKnownRegexPatterns.PrefixAllBase64}(?<refine>[{WellKnownRegexPatterns.Base62}]{{42}}{Signature}[A-D][{WellKnownRegexPatterns.Base64}]{{5}}){WellKnownRegexPatterns.SuffixAllBase64}";
             protected set => base.Pattern = value;
         }
 
         override public uint KeyLength => 39;
+
+        public override IEnumerable<string> GenerateTestExamples()
+        {
+            foreach (var example in base.GenerateTestExamples())
+            {
+                if (example.Contains("_") || example.Contains("-")) { continue; }
+                yield return example;
+            }
+        }
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_176_AzureContainerRegistryIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_176_AzureContainerRegistryIdentifiableKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    internal class AzureContainerRegistryIdentifiableKey : IdentifiableKey
+    public class AzureContainerRegistryIdentifiableKey : IdentifiableKey
     {
         public AzureContainerRegistryIdentifiableKey()
         {

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_190_AzureEventGridIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_190_AzureEventGridIdentifiableKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    internal class AzureEventGridIdentifiableKey : Azure32ByteIdentifiableKey
+    public class AzureEventGridIdentifiableKey : Azure32ByteIdentifiableKey
     {
         public AzureEventGridIdentifiableKey()
         {

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -103,7 +103,7 @@ public static class WellKnownRegexPatterns
                    $"{PrefixUrlUnreserved}(?<refine>[{RegexEncodedUrlUnreserved}]{{3}}8Q~[{RegexEncodedUrlUnreserved}]{{34}}){SuffixUrlUnreserved}",
                    TimeSpan.FromDays(365 * 2),
                    new HashSet<string>(new[] { "8Q~" }),
-                   sampleGenerator: () => new[] { $"zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" });
+                   sampleGenerator: () => new[] { $"zzz8Q~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzblP" });
     }
 
     public static RegexPattern AadClientAppIdentifiableCredentialsPrevious()


### PR DESCRIPTION
- BUG: Correct `AzureCosmosDBIdentifiableKey` rule id to `SEC101/160` (previously incorrectly listed as `SEC101/163`).
