### PR TITLE
chore: avoid packing Benchmark project

### DIFF
--- a/src/Microsoft.Security.Utilities.Benchmarks/Microsoft.Security.Utilities.Benchmarks.csproj
+++ b/src/Microsoft.Security.Utilities.Benchmarks/Microsoft.Security.Utilities.Benchmarks.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <Import Project="$(MsBuildThisFileDirectory)..\Build.props" />


### PR DESCRIPTION
There's no need to pack the Benchmark project,
and doing so slows down the build as well produces extra NuGet packages that most be avoid lest they risk being published if wildcard matching is used.