### PR TITLE
Harden `IdentifiableSecrets.TryValidateCommonAnnotatedKey` for invalid inputs.

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -19,6 +19,7 @@
 - BUG: Remove `/AM7` signature + check from rust code.
 - NEW: Add `SEC101/190.AzureEventGridIdentifiableKey` check.
 - NEW: Create distinct `Detection.CrossCompanyCorrelatingId` property.
+- BUG: Harden `IdentifiableSecrets.TryValidateCommonAnnotatedKey` for a variety of invalid inputs.
 - BUG: Correct `SEC101/170.AzureMLWebServiceClassicIdentifiableKey` signature to `+AMC`.
 - FPS: Correct `SEC101/166.AzureSearchIdentifiableQueryKey` and `SEC101/167.AzureSearchIdentifiableAdminKey` regex to disallow special characters in checksum region.
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -735,7 +735,8 @@ public class SecretMaskerTests
     [TestMethod]
     public void SecretMasker_NotAddShortEncodedSecrets()
     {
-        using var secretMasker = new SecretMasker();
+        string redactionToken = "qqq";
+        using var secretMasker = new SecretMasker(regexSecrets: null, defaultLiteralRedactionToken: redactionToken);
         secretMasker.AddLiteralEncoder(new LiteralEncoder(x => x.Replace("123", "ab")));
         secretMasker.AddValue("123");
         secretMasker.AddValue("345");
@@ -744,7 +745,7 @@ public class SecretMaskerTests
         var input = "ab123cd345";
         var result = secretMasker.MaskSecrets(input);
 
-        Assert.AreEqual("abyyycdyyy", result);
+        Assert.AreEqual(redactionToken, result);
     }
 
     [TestMethod]


### PR DESCRIPTION
- BUG: Harden `IdentifiableSecrets.TryValidateCommonAnnotatedKey` for a variety of invalid inputs.

Partners report to us that this `Try` pattern API throws exceptions for invalid inputs. Now fixed.
