### PR TITLE
Add long form option to request the full HIS v2 key. Expand reporting…

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,7 @@
 - FNS => Flase negative reduction in static analysis.
 
 # UNRELEASED
+- BRK: Add `longForm` argument to `IdentifiableSecrets.GenerateCommonAnnotatedKey`, to produce the optional full 64-byte form (which includes the full 4-byte Marvin checksum).
 - BRK: Coalesce `AadClientAppIdentifiableCredentialsCurrent` and `AadClientAppIdentifiableCredentialsPrevious` into a single `AadClientAppIdentifiableCredentials` check.
 - BRK: Rename `IIdentifiableKey.SniffLiterals` to `IIdentifiableKey.Signatures` to precisely reflect their purpose to signify fixed signatures in keys.
 - BUG: Update `IdentifiableScan` to post-process finds (e.g., with checksum validation) to eliminate false positives.

--- a/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/HighConfidenceMicrosoftSecurityModels/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -24,22 +24,26 @@ namespace Microsoft.Security.Utilities
 
             while(true)
             {
-                char testChar = (char)('a' + attempts++);
-                string example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(IdentifiableSecrets.VersionTwoChecksumSeed,
-                                                                                    "TEST", 
-                                                                                    customerManagedKey: true,
-                                                                                    platformReserved: null,
-                                                                                    providerReserved: null,
-                                                                                    testChar);  
-
-                if (example == null) { continue; }
-
-                if (++count == 10)
+                foreach (bool longForm in new[] { true, false })
                 {
-                    break;
-                }
+                    char testChar = (char)('a' + attempts++);
+                    string example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(IdentifiableSecrets.VersionTwoChecksumSeed,
+                                                                                        "TEST",
+                                                                                        customerManagedKey: true,
+                                                                                        platformReserved: null,
+                                                                                        providerReserved: null,
+                                                                                        longForm: false,
+                                                                                        testChar);
 
-                yield return example;
+                    if (example == null) { continue; }
+
+                    if (++count == 20)
+                    {
+                        break;
+                    }
+
+                    yield return example;
+                }
             }
         }
     }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -80,7 +80,7 @@ public static class IdentifiableSecrets
 
         bool longForm = key.Length == LongFormCommonAnnotatedKeySize;
 
-        string signature = key.Substring(76, 4);
+        string signature = key.Substring(CommonAnnotatedKey.ProviderFixedSignatureOffset, CommonAnnotatedKey.ProviderFixedSignatureLength);
 
         string alternate = char.IsUpper(signature[0]) 
             ? signature.ToLowerInvariant() 
@@ -88,8 +88,8 @@ public static class IdentifiableSecrets
 
         ulong checksumSeed = VersionTwoChecksumSeed;
 
-        string componentToChecksum = key.Substring(0, 80);
-        string checksumText = key.Substring(80);
+        string componentToChecksum = key.Substring(0, CommonAnnotatedKey.ChecksumOffset);
+        string checksumText = key.Substring(CommonAnnotatedKey.ChecksumOffset);
 
         byte[] keyBytes = Convert.FromBase64String(componentToChecksum);
 
@@ -147,7 +147,8 @@ public static class IdentifiableSecrets
         byte[] derivedKeyBytes = new byte[40];
         Array.Copy(hashBytes, derivedKeyBytes, derivedKeyBytes.Length);
 
-        string encodedRandom = derivedKeyBytes.ToBase62().Substring(0, 52);
+        // All data preceding the standard fixed signature comprises the random content.
+        string encodedRandom = derivedKeyBytes.ToBase62().Substring(0, CommonAnnotatedKey.StandardFixedSignatureOffset);
 
         string standardSignature = "JQQJ9D";
 


### PR DESCRIPTION
… for negative cases.

- BRK: Add `longForm` argument to `IdentifiableSecrets.GenerateCommonAnnotatedKey`, to produce the optional full 64-byte form (which includes the full 4-byte Marvin checksum).