### PR TITLE
Add SEC101_061_LooseOAuth2BearerToken and notion of confidence

### DIFF
--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -8,7 +8,7 @@
       "eyAi",
       "ewog"
     ],
-    "DetectionMetadata": "HighEntropy"
+    "DetectionMetadata": "HighEntropy, MediumConfidence"
   },
   {
     "Pattern": "(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))",
@@ -18,7 +18,7 @@
       "sig=",
       "ret="
     ],
-    "DetectionMetadata": "HighEntropy"
+    "DetectionMetadata": "HighEntropy, MediumConfidence"
   },
   {
     "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=$",

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,10 @@
 - FPS => False positive reduction in static analysis.
 - FNS => Flase negative reduction in static analysis.
 
+# 1.5 PLEASE START TO VERSION MINOR NUMBER FOR BREAKING CHANGES
+- RUL: Add `SEC101/061.LooseOAuth2BearerToken` detection.
+- NEW: Add `DetectionMetadata.LowConfidence` and `Detection.MediumConfidence` designations.
+
 # 1.4.25 - 06/04/2024
 - BUG: Bring `IdentifiableScan` into precise equivalence with other maskers, e.g., `Detection.RedactionToken` is now in alignment.
 - NEW: Provide hybrid capability to run high-performance detections in `IdentifiableScan` and fall back to other masker as required.

--- a/src/Microsoft.Security.Utilities.Core/DetectionMetadata.cs
+++ b/src/Microsoft.Security.Utilities.Core/DetectionMetadata.cs
@@ -20,7 +20,13 @@ public enum DetectionMetadata
 
     ClearSurroundingContext = 1 << 4,
 
-    Identifiable = FixedSignature | EmbeddedChecksum | HighEntropy,
+    Identifiable = FixedSignature | EmbeddedChecksum | HighEntropy | HighConfidence,
 
     RequiresRotation = 1 << 5,
+
+    LowConfidence = 1 << 6,
+
+    MediumConfidence = 1 << 7,
+
+    HighConfidence = 1 << 8,
 }

--- a/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_060_LooseSasSecret.cs
+++ b/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_060_LooseSasSecret.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/060";
             Name = nameof(LooseSasSecret);
-            DetectionMetadata = DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.MediumConfidence;
             Pattern = @$"(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?<refine>[0-9a-z\/+%]{{43,129}}(?:=|%3d))";
             Signatures = new HashSet<string>(new[] { "sig=", "ret=" });
         }

--- a/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_061_LooseOAuth2BearerToken.cs
+++ b/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_061_LooseOAuth2BearerToken.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Security.Utilities
+{
+    public class OAuth2BearerToken : RegexPattern
+    {
+        public OAuth2BearerToken()
+        {
+            Id = "SEC101/061";
+            Name = nameof(OAuth2BearerToken);
+            DetectionMetadata = DetectionMetadata.LowConfidence;
+
+            // https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+            Pattern = $"(?i)authorization:(\\s|%20)bearer(\\s|%20)<?<refine>[0-9a-z][{WellKnownRegexPatterns.UrlUnreserved}+/=]*)[^[{WellKnownRegexPatterns.UrlUnreserved}+/=]";
+            Signatures = new HashSet<string>(new[] { "sig=", "ret=" });
+        }
+
+        public override IEnumerable<string> GenerateTruePositiveExamples()
+        {
+            yield return $"Authorization: bearer notasecret==";
+            yield return $"authorization:%20bearer%20secretplacholder";
+        }
+    }
+}

--- a/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_528_GenericJwt.cs
+++ b/src/Microsoft.Security.Utilities.Core/UnclassifiedPotentialSecurityKeys/SEC101_528_GenericJwt.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/528";
             Name = nameof(GenericJwt);
-            DetectionMetadata = DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.MediumConfidence;
             Pattern = @$"(?:^|[^0-9A-Za-z-_.])e[0-9A-Za-z-_=]{{23,}}\.e[0-9A-Za-z-_=]{{23,}}\.[0-9A-Za-z-_=]{{24,}}(?:[^0-9A-Za-z-_]|$)";
 
             // These signatures represent base64-encoding of the following


### PR DESCRIPTION
- RUL: Add `SEC101/061.LooseOAuth2BearerToken` detection.
- NEW: Add `DetectionMetadata.LowConfidence` and `Detection.MediumConfidence` designations.

This change first adds a detection requested by a partner, for detecting and redacting a loose OAuth2.0 bearer token. The data stored in this header location appears to itself have different patterns and conventions (for example, a simple base64 encoded token or a CBOR web token).

The corresponding rule doesn't make an effort to classify these or try to determine whether the provided value is recognizable, e.g., as a 32-byte base64-encoded value.

That leads me to mark is a 'low confidence'. i.e., we expect to redact test/other non-sensitive data as well as actual secrets with this pattern. 
