### PR TITLE
Fixing SEC101/200 GenerateTruePositiveExamples test case

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -9,11 +9,13 @@
 - NEW => New API or feature.
 - PRF => Performance work.
 - FPS => False positive reduction in static analysis.
-- FNS => Flase negative reduction in static analysis.
+- FNS => False negative reduction in static analysis.
 
 # 1.5 PLEASE START TO VERSION MINOR NUMBER FOR BREAKING CHANGES
 - RUL: Add `SEC101/061.LooseOAuth2BearerToken` detection.
 - DEP: Added support for net451 in `Microsoft.Security.Utilities.Core` for backward compatibility.
+- BUG: Fix the logic in `CommonAnnotatedSecurityKey.GenerateTruePositiveExamples()` to handle invalid test key characters, and to properly break out of the testing loop.
+- FNS: Added `SEC101/200.CommonAnnotatedSecurityKey` to `WellKnownPatterns.HighConfidenceMicrosoftSecurityModels`.
 - NEW: Add `DetectionMetadata.LowConfidence` and `Detection.MediumConfidence` designations.
 
 # 1.4.25 - 06/04/2024

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/Azure64ByteIdentifiableKeys.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/Azure64ByteIdentifiableKeys.cs
@@ -46,7 +46,7 @@ internal sealed class Azure64ByteIdentifiableKeys : RegexPattern
             IdentifiableMetadata.AzureApimSignature => GetApimMatchIdAndName(match),
             IdentifiableMetadata.AzureBatchSignature => new Tuple<string, string>("SEC101/163", "AzureBatchIdentifiableKey"),
             IdentifiableMetadata.AzureStorageSignature => new Tuple<string, string>("SEC101/152", "AzureStorageAccountIdentifiableKey"),
-            IdentifiableMetadata.AzureCosmosDBSignature => new Tuple<string, string>("SEC101/160", "AzureCosmosDbIdentifiableKeyResource"),
+            IdentifiableMetadata.AzureCosmosDBSignature => new Tuple<string, string>("SEC101/160", "AzureCosmosDBIdentifiableKey"),
             IdentifiableMetadata.AzureMLClassicSignature => new Tuple<string, string>("SEC101/170", "AzureMLWebServiceClassicIdentifiableKey"),
             _ => null,
         };

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -22,25 +22,40 @@ namespace Microsoft.Security.Utilities
             int count = 0;
             int attempts = 0;
 
-            while(true)
+            foreach (bool longForm in new[] { true, false })
             {
-                foreach (bool longForm in new[] { true, false })
+                while (true) 
                 {
                     char testChar = (char)('a' + attempts++);
-                    string example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(IdentifiableSecrets.VersionTwoChecksumSeed,
-                                                                                        "TEST",
-                                                                                        customerManagedKey: true,
-                                                                                        platformReserved: null,
-                                                                                        providerReserved: null,
-                                                                                        longForm: false,
-                                                                                        testChar);
 
-                    if (example == null) { continue; }
+                    if (testChar == '{')
+                    {
+                        int z = 10;
+                    }
 
-                    if (++count == 20)
+                    string example;
+
+                    try
+                    { 
+                        example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(IdentifiableSecrets.VersionTwoChecksumSeed,
+                                                                                     "TEST",
+                                                                                     customerManagedKey: true,
+                                                                                     platformReserved: null,
+                                                                                     providerReserved: null,
+                                                                                     longForm,
+                                                                                     testChar);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        example = null;
+                    }
+
+                    if (++count > 26)
                     {
                         break;
                     }
+
+                    if (example == null) { continue; }
 
                     yield return example;
                 }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Security.Utilities
 
         public override IEnumerable<string> GenerateTruePositiveExamples()
         {
-            int count = 0;
             int attempts = 0;
 
             foreach (bool longForm in new[] { true, false })
@@ -30,7 +29,7 @@ namespace Microsoft.Security.Utilities
 
                     if (testChar == '{')
                     {
-                        int z = 10;
+                        break;
                     }
 
                     string example;
@@ -48,11 +47,6 @@ namespace Microsoft.Security.Utilities
                     catch (InvalidOperationException)
                     {
                         example = null;
-                    }
-
-                    if (++count > 26)
-                    {
-                        break;
                     }
 
                     if (example == null) { continue; }

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -58,6 +58,7 @@ public static class WellKnownRegexPatterns
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
     {
+        new CommonAnnotatedSecurityKey(),
         new AadClientAppIdentifiableCredentials(),
         new AzureFunctionIdentifiableKey(),
         new AzureSearchIdentifiableQueryKey(),

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -58,7 +58,7 @@ public static class WellKnownRegexPatterns
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
     {
-        new CommonAnnotatedSecurityKey(),
+        //new CommonAnnotatedSecurityKey(),
         new AadClientAppIdentifiableCredentials(),
         new AzureFunctionIdentifiableKey(),
         new AzureSearchIdentifiableQueryKey(),

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -54,6 +54,8 @@ public static class WellKnownRegexPatterns
         new Unclassified32ByteBase64String(),
         new Unclassified64ByteBase64String(),
         new Unclassified16ByteHexadecimalString(),
+         
+        // Tracking issue with UrlCredentials via https://github.com/microsoft/security-utilities/issues/48
         // new UrlCredentials()
     };
 
@@ -80,6 +82,8 @@ public static class WellKnownRegexPatterns
         new AzureApimIdentifiableRepositoryKey(),
         new AzureCacheForRedisIdentifiableKey(),
         new AzureContainerRegistryIdentifiableKey(),
+
+        // Tracking issue with AzureContainerRegistryLegacyKey via https://github.com/microsoft/security-utilities/issues/49
         // new AzureContainerRegistryLegacyKey(),
         new NuGetApiKey(),
         new AadClientAppLegacyCredentials32(),      // SEC101/101

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -54,7 +54,7 @@ public static class WellKnownRegexPatterns
         new Unclassified32ByteBase64String(),
         new Unclassified64ByteBase64String(),
         new Unclassified16ByteHexadecimalString(),
-        new UrlCredentials()
+        // new UrlCredentials()
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
@@ -80,7 +80,7 @@ public static class WellKnownRegexPatterns
         new AzureApimIdentifiableRepositoryKey(),
         new AzureCacheForRedisIdentifiableKey(),
         new AzureContainerRegistryIdentifiableKey(),
-        new AzureContainerRegistryLegacyKey(),
+        // new AzureContainerRegistryLegacyKey(),
         new NuGetApiKey(),
         new AadClientAppLegacyCredentials32(),      // SEC101/101
         new AadClientAppLegacyCredentials34(),      // SEC101/101

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -54,11 +54,12 @@ public static class WellKnownRegexPatterns
         new Unclassified32ByteBase64String(),
         new Unclassified64ByteBase64String(),
         new Unclassified16ByteHexadecimalString(),
+        new UrlCredentials()
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
     {
-        //new CommonAnnotatedSecurityKey(),
+        new CommonAnnotatedSecurityKey(),
         new AadClientAppIdentifiableCredentials(),
         new AzureFunctionIdentifiableKey(),
         new AzureSearchIdentifiableQueryKey(),
@@ -79,6 +80,7 @@ public static class WellKnownRegexPatterns
         new AzureApimIdentifiableRepositoryKey(),
         new AzureCacheForRedisIdentifiableKey(),
         new AzureContainerRegistryIdentifiableKey(),
+        new AzureContainerRegistryLegacyKey(),
         new NuGetApiKey(),
         new AadClientAppLegacyCredentials32(),      // SEC101/101
         new AadClientAppLegacyCredentials34(),      // SEC101/101

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Xml.Linq;
 
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Security.Utilities
+{
+    [TestClass]
+    public class WellKnownRegexPatternsTests
+    {
+        [TestMethod]
+        public void WellKnownRegexPatterns_EnsureAllPatternsAreReferenced()
+        {
+            using var assertionScope = new AssertionScope();
+
+            var rulesets = new[]{
+                WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
+                WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
+            };
+
+            HashSet<string> wellKnownMonikers = new HashSet<string>();
+
+            foreach (IEnumerable<RegexPattern> ruleset in rulesets)
+            {
+                foreach (RegexPattern pattern in ruleset)
+                {
+                    foreach (string example in pattern.GenerateTruePositiveExamples())
+                    {
+                        wellKnownMonikers.Add(pattern.GetMatchMoniker(example));
+                    }
+                }
+            }
+
+            Assembly coreAssembly = typeof(WellKnownRegexPatterns).Assembly;
+
+            HashSet<string> unrecognizedMonikers = new HashSet<string>();
+
+            foreach (Type type in coreAssembly.GetTypes())
+            {
+                if (type.IsAbstract || !type.IsSubclassOf(typeof(RegexPattern)))
+                {
+                    continue;
+                }
+
+                RegexPattern pattern = (RegexPattern)Activator.CreateInstance(type);
+
+                foreach (string example in pattern.GenerateTruePositiveExamples())
+                {
+                    string moniker = pattern.GetMatchMoniker(example);
+                    if (!wellKnownMonikers.Contains(moniker))
+                    {
+                        unrecognizedMonikers.Add(moniker);
+                    }
+
+                }
+            }
+
+            foreach (string unrecognizedMoniker in unrecognizedMonikers)
+            {
+                false.Should().BeTrue(because: $"'{unrecognizedMoniker}' should be referenced by a WellKnownPatterns ruleset");
+            }
+        }
+    }
+}

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -14,6 +14,17 @@ namespace Microsoft.Security.Utilities
     [TestClass]
     public class WellKnownRegexPatternsTests
     {
+        /// <summary>
+        /// This list should be empty.
+        /// If it isn't, then it indicates failures associated with the corresponding rules.
+        /// Check https://github.com/microsoft/security-utilities/issues for open issues.
+        /// </summary>
+        private readonly List<string> WellKnownRegexPatternsExclusionList = new()
+        {
+            "SEC101/127.UrlCredentials",
+            "SEC101/109.AzureContainerRegistryLegacyKey"
+        };
+
         [TestMethod]
         public void WellKnownRegexPatterns_EnsureAllPatternsAreReferenced()
         {
@@ -63,6 +74,11 @@ namespace Microsoft.Security.Utilities
 
             foreach (string unrecognizedMoniker in unrecognizedMonikers)
             {
+                if (WellKnownRegexPatternsExclusionList.Contains(unrecognizedMoniker))
+                {
+                    continue;
+                }
+
                 false.Should().BeTrue(because: $"'{unrecognizedMoniker}' should be referenced by a WellKnownPatterns ruleset");
             }
         }


### PR DESCRIPTION
This PR
1. Adds `CommonAnnotatedSecurityKey` to the high confidence security models set.
2. Fixes the test in `GenerateTruePositiveExamples` for `CommonAnnotatedSecurityKey`. The logic was completely broken.
3. Added release note entry for the same.