### PR TITLE
Adding support for .NET 451 for backwards compatibility

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => Flase negative reduction in static analysis.
 
+# UNRELEASED
+- DEP: Added support for net451 in `Microsoft.Security.Utilities.Core` for backward compatibility.
+
 # 1.4.25 - 06/04/2024
 - BUG: Bring `IdentifiableScan` into precise equivalence with other maskers, e.g., `Detection.RedactionToken` is now in alignment.
 - NEW: Provide hybrid capability to run high-performance detections in `IdentifiableScan` and fall back to other masker as required.

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -96,6 +96,12 @@ if ($LASTEXITCODE -ne 0) {
     Exit-WithFailureMessage $ScriptName "Build of SecurityUtilitiesPackageReference failed."
 }
 
+Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net451..."
+Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net451\SecurityUtilitiesApiUtilizationExample.exe"
+if ($LASTEXITCODE -ne 0) {
+    Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+}
+
 Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net462..."
 Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net462\SecurityUtilitiesApiUtilizationExample.exe"
 if ($LASTEXITCODE -ne 0) {

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -226,7 +226,8 @@ public static class IdentifiableSecrets
             if (testChar == null)
             {
                 using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(keyBytes, 0, (int)keyLengthInBytes);
+
+                generator.GetBytes(keyBytes);
 
                 key = keyBytes.ToBase62();
                 
@@ -391,7 +392,7 @@ public static class IdentifiableSecrets
         byte[] randomBytes = new byte[(int)keyLengthInBytes];
 
         using var generator = RandomNumberGenerator.Create();
-        generator.GetBytes(randomBytes, 0, (int)keyLengthInBytes);
+        generator.GetBytes(randomBytes);
 
         string secret = GenerateBase64KeyHelper(checksumSeed,
                                                 keyLengthInBytes,
@@ -422,7 +423,7 @@ public static class IdentifiableSecrets
         byte[] randomBytes = new byte[(int)keyLengthInBytes];
 
         using var generator = RandomNumberGenerator.Create();
-        generator.GetBytes(randomBytes, 0, (int)keyLengthInBytes);
+        generator.GetBytes(randomBytes);
 
         return GenerateBase64KeyHelper(checksumSeed,
                                        keyLengthInBytes,
@@ -481,7 +482,7 @@ public static class IdentifiableSecrets
         {
             randomBytes = new byte[(int)keyLengthInBytes];
             using var generator = RandomNumberGenerator.Create();
-            generator.GetBytes(randomBytes, 0, (int)keyLengthInBytes);
+            generator.GetBytes(randomBytes);
         }
 
         return GenerateKeyWithAppendedSignatureAndChecksum(randomBytes,

--- a/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
+++ b/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>net462;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Security.Utilities
 
             if (string.IsNullOrEmpty(inputString))
             {
-                return Array.Empty<byte>();
+                return new byte[0];
             }
 
             int outputSize = inputString.Length * OutputPerByteSize / InputPerByteSize;

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Security.Utilities
 {
     public class AdoPat : RegexPattern
     {
+        private static readonly byte[] EmptyByteArray = new byte[0];
+
         public AdoPat() 
         {
             Id = "SEC101/102";
@@ -73,7 +75,7 @@ namespace Microsoft.Security.Utilities
 
             if (string.IsNullOrEmpty(inputString))
             {
-                return new byte[0];
+                return EmptyByteArray;
             }
 
             int outputSize = inputString.Length * OutputPerByteSize / InputPerByteSize;

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Security.Utilities
 {
     public class AzureStorageAccountLegacyCredentials : RegexPattern
     {
+        private static readonly byte[] EmptyByteArray = new byte[0];
+
         public AzureStorageAccountLegacyCredentials() 
         {
             Id = "SEC101/106";
@@ -72,7 +74,7 @@ namespace Microsoft.Security.Utilities
 
             if (string.IsNullOrEmpty(inputString))
             {
-                return new byte[0];
+                return EmptyByteArray;
             }
 
             int outputSize = inputString.Length * OutputPerByteSize / InputPerByteSize;

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Security.Utilities
 
             if (string.IsNullOrEmpty(inputString))
             {
-                return Array.Empty<byte>();
+                return new byte[0];
             }
 
             int outputSize = inputString.Length * OutputPerByteSize / InputPerByteSize;

--- a/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/SecurityUtilitiesApiUtilizationExample.csproj
+++ b/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/SecurityUtilitiesApiUtilizationExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFrameworks>net462;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net451;net462;net6.0</TargetFrameworks>
 	  <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 


### PR DESCRIPTION
Some consumers of `security-utilities` are on older versions of .Net. This PR adds support for .net451 in `Microsoft.Security.Utilities.Core` to improve backward compatibility.