### PR TITLE
OAuth2BearerToken test disabled, versions updated

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -57,6 +57,9 @@ public static class WellKnownRegexPatterns
          
         // Tracking issue with UrlCredentials via https://github.com/microsoft/security-utilities/issues/48
         // new UrlCredentials()
+
+        // Tracking issue with LooseOAuth2BearerToken via https://github.com/microsoft/security-utilities/issues/51
+        //new OAuth2BearerToken()
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Security.Utilities
         private readonly List<string> WellKnownRegexPatternsExclusionList = new()
         {
             "SEC101/127.UrlCredentials",
-            "SEC101/109.AzureContainerRegistryLegacyKey"
+            "SEC101/109.AzureContainerRegistryLegacyKey",
+            "SEC101/061.OAuth2BearerToken"
         };
 
         [TestMethod]

--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core"
-version = "1.4.25"
+version = "1.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/security_utilities_rust_ffi/Cargo.toml
+++ b/src/security_utilities_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core_ffi"
-version = "1.4.25"
+version = "1.5.0"
 edition = "2021"
 
 [lib]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.22",
+  "version": "1.5.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
Added OAuth2BearerToken to `WellKnownRegexPatterns`. Had to add it to the exclusion list in the tests due a regex parsing bug (opened a issue). 
No Release Notes entry since there is effectively no external change.