### PR TITLE
Eliminate a rule from the WellKnownRegexPatterns list

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -61,7 +61,6 @@ public static class WellKnownRegexPatterns
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
     {
-        new AzureContainerRegistryLegacyKey(),
         new CommonAnnotatedSecurityKey(),
         new AadClientAppIdentifiableCredentials(),
         new AzureFunctionIdentifiableKey(),


### PR DESCRIPTION
This rule was already eliminated, but persisted in the `WellKnownRegexPatterns` list.