### PR TITLE
Fixing compiler warnings

### DIFF
--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#[cfg(test)]
+#![cfg(test)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
 use super::*;
 use std::{collections::HashSet};
 use rand::prelude::*;
@@ -169,7 +172,7 @@ fn identifiable_secrets_compute_checksum_seed_enforces_length_requirement()
     {
         let literal = "A".repeat(i) + "0";
 
-        let mut result = std::panic::catch_unwind(|| microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(&literal));
+        let result = std::panic::catch_unwind(|| microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(&literal));
 
         if i == 7 
         {
@@ -187,11 +190,11 @@ fn identifiable_secrets_platform_annotated_security_keys() {
     let mut keys_generated: u64 = 0;
     let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-    for i in 0..iterations 
+    for _i in 0..iterations
     {
-        for j in 0..iterations 
+        for _j in 0..iterations
         {
-            for k in 0..iterations 
+            for _k in 0..iterations
             {
                 let mut signature: String = format!("{:?}", Uuid::new_v4().simple()).chars().skip(1).take(4).collect::<String>();
 
@@ -497,7 +500,7 @@ fn identifiable_secrets_generate_standard_base64_key_basic()
         key_length_in_bytes,
         signature.as_str());
         
-        // validate_secret(secret, seed, signature, false);
+        validate_secret(secret, seed, signature, false);
     }
 }
 

--- a/src/security_utilities_rust/src/marvin_tests.rs
+++ b/src/security_utilities_rust/src/marvin_tests.rs
@@ -1,4 +1,11 @@
-#[cfg(test)]
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#![cfg(test)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+
 use super::*;
 
 /// Compare a Marvin checksum against a well-known test case from the native code.

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -1156,7 +1156,7 @@ mod tests {
 
     #[test]
     fn his_v1_scan_bytes() {
-        let mut options = ScanOptions::default();
+        let options = ScanOptions::default();
 
         let mut scan = Scan::new(options);
         let empty: [u8; 0] = [0; 0];

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+
 use base_62;
 use base64::{engine::general_purpose, Engine as _};
 use chrono::Datelike;


### PR DESCRIPTION
This PR makes a bunch of cleanup changes to silence all the Rust compilation warnings. The fixes are a combination of fixes to valid compiler complaints, and silencing classes of alerts which were being incorrectly raised.