### PR TITLE
Adding an initial secret masking capability

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,7 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
+# 1.5.2 - 07/05/2024
 - NEW: Added an initial secret redaction capability to the Rust package.
 
 # 1.5.1 - 06/27/2024

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- NEW: Added an initial secret redaction capability to the Rust package.
+
 # 1.5.1 - 06/27/2024
 - DEP: Rust packages now depend on `msvc_spectre_libs` to link Spectre-mitigated libraries for `msvc` targets.
 - NEW: Rust packages now support common annotated security key generation and validation, with semantics equivalent to C# version.

--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core"
-version = "1.5.1"
+version = "1.5.2
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core"
-version = "1.5.2
+version = "1.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/security_utilities_rust/src/end_to_end_tests.rs
+++ b/src/security_utilities_rust/src/end_to_end_tests.rs
@@ -55,7 +55,7 @@ fn identifiable_scanning_and_validation_perf_benchmark() {
             Some(&vec![0; 9]),
             Some(&vec![0; 3]),
             true,
-            Some('a')
+            Some('A')
         );
 
         let generated_input = valid_key.clone().unwrap();

--- a/src/security_utilities_rust/src/end_to_end_tests.rs
+++ b/src/security_utilities_rust/src/end_to_end_tests.rs
@@ -47,7 +47,7 @@ fn identifiable_scanning_and_validation_perf_benchmark() {
     let options = microsoft_security_utilities_core::identifiable_scans::ScanOptions::default();
     let mut scan = microsoft_security_utilities_core::identifiable_scans::Scan::new(options);
 
-    for _ in 0..1_000_000 {
+    for _ in 0..1000 {
         let valid_key = microsoft_security_utilities_core::identifiable_secrets::
         generate_common_annotated_key(
             valid_signature,

--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -10,8 +10,37 @@ use std::{collections::HashSet};
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 use uuid::Uuid;
+use crate::microsoft_security_utilities_core::identifiable_secrets::SecretMasker;
 
 static S_BASE62_ALPHABET: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+#[test]
+fn secret_masker_test() {
+    let valid_signature = "ABCD";
+    let valid_key = microsoft_security_utilities_core::identifiable_secrets::
+    generate_common_annotated_key(
+        valid_signature,
+        true,
+        Some(&vec![0; 9]),
+        Some(&vec![0; 3]),
+        true,
+        Some('A')
+    );
+
+    let valid_key = valid_key.unwrap().clone();
+
+    let input = format!("{} test_string {}", valid_key, valid_key);
+
+    let options = microsoft_security_utilities_core::identifiable_scans::ScanOptions::default();
+
+    let mut secret_masker = SecretMasker {
+        scan:  microsoft_security_utilities_core::identifiable_scans::Scan::new(options)
+    };
+
+    let masked_valid_key = secret_masker.mask_secrets(&input, None, false);
+
+    println!("{}", masked_valid_key);
+}
 
 #[test]
 fn identifiable_secrets_try_validate_common_annotated_key_generate_common_annotated_key_long_form() {

--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -44,22 +44,23 @@ fn secret_masker_test() {
 
         let valid_key = valid_key.unwrap().clone();
 
-        let input = format!("{} test_string {}", valid_key, valid_key);
+        let mut input = format!("{} test_string {}", valid_key, valid_key);
         let valid_key_c3id = cross_company_correlating_id::generate_cross_company_correlating_id(&valid_key);
         let redacted_input = format!("SEC101/200:{} test_string SEC101/200:{}", valid_key_c3id, valid_key_c3id);
 
         let start = Instant::now();
-        let masked_valid_key_checksum = secret_masker.mask_secrets(&input, None, true);
+        secret_masker.mask_secrets(&mut input, None, true);
         let duration = start.elapsed();
 
-        assert_eq!(masked_valid_key_checksum, redacted_input);
+        assert_eq!(input, redacted_input);
         masking_times_with_checksum_validation.push(duration);
 
+        let mut input = format!("{} test_string {}", valid_key, valid_key);
         let start = Instant::now();
-        let masked_valid_key_no_checksum = secret_masker.mask_secrets(&input, None, false);
+        secret_masker.mask_secrets(&mut input, None, false);
         let duration = start.elapsed();
 
-        assert_eq!(masked_valid_key_no_checksum, redacted_input);
+        assert_eq!(input, redacted_input);
         masking_times_without_checksum_validation.push(duration);
     }
 

--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -30,7 +30,7 @@ fn secret_masker_test() {
         scan:  microsoft_security_utilities_core::identifiable_scans::Scan::new(options)
     };
 
-    for _ in 0..1_000_000 {
+    for _ in 0..1000 {
         // generate a key
         let valid_key = microsoft_security_utilities_core::identifiable_secrets::
         generate_common_annotated_key(

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -102,11 +102,12 @@ impl ScanMatch {
     }
 }
 
+#[derive(Clone)]
 pub struct PossibleScanMatch {
     name: &'static str,
     def_index: u32,
-    start: u64,
-    len: usize,
+    pub start: u64,
+    pub len: usize,
     utf8: bool,
     validator: Rc<dyn Fn(&[u8]) -> usize>,
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -106,8 +106,8 @@ impl ScanMatch {
 pub struct PossibleScanMatch {
     name: &'static str,
     def_index: u32,
-    pub start: u64,
-    pub len: usize,
+    start: u64,
+    len: usize,
     utf8: bool,
     validator: Rc<dyn Fn(&[u8]) -> usize>,
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -11,12 +11,15 @@ use chrono::Datelike;
 use core::panic;
 use lazy_static::lazy_static;
 use std::{mem};
+use std::any::Any;
 use super::*;
 use rand::prelude::*;
 use rand::RngCore;
 use rand_chacha::ChaCha20Rng;
 use regex::Regex;
 use substring::Substring;
+use crate::microsoft_security_utilities_core;
+use crate::microsoft_security_utilities_core::identifiable_scans::PossibleScanMatch;
 
 lazy_static! {
     pub static ref VERSION_TWO_CHECKSUM_SEED: u64 = compute_his_v1_checksum_seed("Default0");
@@ -810,4 +813,96 @@ fn index_of(input_string: String, search_char: char) -> i32
         Some(index) => index as i32
     }
 }
+
+#[derive(Clone)]
+struct Detection {
+    start: u64,
+    end: u64,
+    length: usize,
+    redaction_token: String
+}
+
+pub struct SecretMasker {
+    pub scan: identifiable_scans::Scan
+}
+
+impl SecretMasker {
+    pub fn mask_secrets(&mut self, input: &str, default_redaction_token: Option<&str>, validate_checksum: bool) -> String {
+        if input.is_empty() {
+            return String::new();
+        }
+
+        let input_as_bytes = input.as_bytes();
+        self.scan.parse_bytes(input_as_bytes);
+
+        let detections = self.scan.possible_matches();
+        let mut detections = detections.clone();
+
+        // Short-circuit if nothing to replace.
+        if detections.is_empty() {
+            return input.to_string();
+        }
+
+        // Merge positions into ranges of characters to replace.
+        let mut current_detections = Vec::new();
+        let mut current_detection : Option<Detection> = None;
+
+        detections.sort_unstable_by_key(|item| item.start);
+
+        for detection in detections.iter() {
+            let scan_match = detection.matches_bytes(input_as_bytes, true).unwrap();
+            let match_text = scan_match.text();
+
+            // Get c3id for the find
+            let match_text_c3id = cross_company_correlating_id::generate_cross_company_correlating_id(match_text);
+
+            let redaction_token = match default_redaction_token {
+                Some(token) => token,
+                None => &format!("SEC101/200:{}", match_text_c3id),
+            };
+
+            if current_detection.is_none() {
+                current_detection = Some(Detection {
+                    start: detection.start(),
+                    end: detection.start() + detection.len() as u64,
+                    length: detection.len(),
+                    redaction_token: redaction_token.to_string()
+                });
+                current_detections.push(current_detection.clone().unwrap());
+            }
+            else {
+                if detection.start <= current_detection.clone().unwrap().end {
+                    // Overlapping case or contiguous case.
+                    let current = current_detection.as_mut().unwrap();
+                    current.length = (std::cmp::max(current.end,
+                                                    detection.start() + detection.len() as u64)
+                        - current.start) as usize;
+                } else {
+                    current_detection = Some(Detection {
+                        start: detection.start(),
+                        end: detection.start() + detection.len() as u64,
+                        length: detection.len(),
+                        redaction_token: redaction_token.to_string()
+                    });
+                    current_detections.push(current_detection.clone().unwrap());
+                }
+            }
+        }
+
+        let mut result = String::new();
+        let mut start_index = 0;
+        for detection in current_detections {
+            result.push_str(&input[start_index as usize..detection.start as usize]);
+            result.push_str(&detection.redaction_token);
+            start_index = detection.start + detection.length as u64;
+        }
+
+        if start_index < input.len() as u64 {
+            result.push_str(&input[start_index as usize..]);
+        }
+
+        result
+    }
+}
+
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -827,11 +827,9 @@ pub struct SecretMasker {
 }
 
 impl SecretMasker {
-    pub fn mask_secrets(&mut self, input: &mut String, default_redaction_token: Option<&str>, validate_checksum: bool) -> Option<String> {
-        let default_return = String::new();
-
+    pub fn mask_secrets(&mut self, input: &mut String, default_redaction_token: Option<&str>, validate_checksum: bool) -> bool {
         if input.is_empty() {
-            return Some(default_return);
+            return false;
         }
 
         self.scan.reset();
@@ -843,7 +841,7 @@ impl SecretMasker {
 
         // Short-circuit if nothing to replace.
         if detections.is_empty() {
-            return None;
+            return false;
         }
 
         let mut detections = detections.clone();
@@ -917,7 +915,7 @@ impl SecretMasker {
             index_adjustment += detection.length - detection.redaction_token.len();
         }
 
-        Some(default_return)
+        true
     }
 }
 

--- a/src/security_utilities_rust_ffi/Cargo.toml
+++ b/src/security_utilities_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core_ffi"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 
 [lib]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
This PR adds an initial secret masking capability to Rust. For a given input, the masker leverages the high performance scanner to compute finds, optionally performs checksum validation, and then redacts finds. The redaction token can be specified by the user, otherwise it defaults to `SEC101/200 : c3id`, where `c3id` is the cross-company correlating id for the find.

The PR also adds a test to highlight the usage of the API, and benchmarks the performance with and without checksum validation. On my machine, the performance was:

Mean time for masking with checksum validation: 97.798µs
Mean time for masking without checksum validation: 80.614µs

_Edit_
I implemented an "in-place" redaction, based on PR feedback from @beaubelgrave . The resulting performance is:
Mean time for masking with checksum validation: 66.662µs
Mean time for masking without checksum validation: 55.299µs