### PR TITLE
Rust compiler E0716 error fix

### DIFF
--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -880,7 +880,7 @@ impl SecretMasker {
 
             let redaction_token = match default_redaction_token {
                 Some(token) => token,
-                None => &c3id_redaction_format.clone(),
+                None => &c3id_redaction_format
             };
 
             if current_detection.is_none() {

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -876,9 +876,11 @@ impl SecretMasker {
             // Get c3id for the find
             let match_text_c3id = cross_company_correlating_id::generate_cross_company_correlating_id(match_text);
 
+            let c3id_redaction_format = format!("SEC101/200:{}", match_text_c3id);
+
             let redaction_token = match default_redaction_token {
                 Some(token) => token,
-                None => &format!("SEC101/200:{}", match_text_c3id),
+                None => &c3id_redaction_format.clone(),
             };
 
             if current_detection.is_none() {


### PR DESCRIPTION
This PR makes a fix for `E0716: a temporary value is being dropped while a borrow is still in active use`.