### PR TITLE
Improve scan runtime measured in `identifiable_scanning_and_validation_perf_benchmark` by ~20%

### DIFF
--- a/src/security_utilities_rust/src/end_to_end_tests.rs
+++ b/src/security_utilities_rust/src/end_to_end_tests.rs
@@ -47,7 +47,13 @@ fn identifiable_scanning_and_validation_perf_benchmark() {
     let options = microsoft_security_utilities_core::identifiable_scans::ScanOptions::default();
     let mut scan = microsoft_security_utilities_core::identifiable_scans::Scan::new(options);
 
-    for _ in 0..1000 {
+    #[cfg(debug_assertions)]
+    let iterations = 1_000;
+
+    #[cfg(not(debug_assertions))]
+    let iterations = 5_000_000;
+
+    for _ in 0..iterations {
         let valid_key = microsoft_security_utilities_core::identifiable_secrets::
         generate_common_annotated_key(
             valid_signature,

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -1026,6 +1026,11 @@ impl Scan {
         self.must_scan = (self.index - sig_index) < 8;
     }
 
+        /// Parse `data` without resetting the internal state, and appending
+    /// any newly found possible matches to `checks`.
+    ///
+    /// If `data` points to a different stream than data previously processed
+    /// by this [`Scan`], you _must_ call [`Scan::reset`] first.
     pub fn parse_bytes(
         &mut self,
         data: &[u8]) {

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-use std::rc::Rc;
-
 /* Indicates the char is part of a small mask */
 const MASK_SMALL: u8 = 1 << 0;
 
@@ -109,7 +107,7 @@ pub struct PossibleScanMatch {
     start: u64,
     len: usize,
     utf8: bool,
-    validator: Rc<dyn Fn(&[u8]) -> usize>,
+    validator: fn(&[u8]) -> usize,
 }
 
 impl PossibleScanMatch {
@@ -119,7 +117,7 @@ impl PossibleScanMatch {
         start: u64,
         len: usize,
         utf8: bool,
-        validator: Rc<dyn Fn(&[u8]) -> usize>) -> Self {
+        validator: fn(&[u8]) -> usize) -> Self {
         Self {
             name,
             def_index,
@@ -257,7 +255,7 @@ pub struct ScanDefinition {
     mask_size: u8,
     packed_utf8: u64,
     packed_utf16: u64,
-    validator: Rc<dyn Fn(&[u8]) -> usize>,
+    validator: fn(&[u8]) -> usize,
 }
 
 impl ScanDefinition {
@@ -267,7 +265,7 @@ impl ScanDefinition {
         sig_char: u8,
         before: u64,
         len: usize,
-        validator: impl Fn(&[u8]) -> usize + 'static) -> Self {
+        validator: fn(&[u8]) -> usize) -> Self {
         match sig.len() {
             3 | 4 => { },
             _ => { panic!("Signature has to be 3 or 4 bytes"); }
@@ -302,7 +300,7 @@ impl ScanDefinition {
             mask_size,
             packed_utf8: Self::pack_utf8(sig),
             packed_utf16: Self::pack_utf16(sig),
-            validator: Rc::new(validator),
+            validator,
         }
     }
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -328,7 +328,7 @@ impl ScanDefinition {
         packed
     }
 
-    fn possible_utf8_match(&self, index: u64) -> Option<PossibleScanMatch> {
+    fn has_possible_utf8_match(&self, index: u64) -> Option<PossibleScanMatch> {
         if index >= self.before_utf8 {
             Some(PossibleScanMatch::new(
                 self.name,
@@ -343,7 +343,7 @@ impl ScanDefinition {
         }
     }
 
-    fn possible_utf16_match(&self, index: u64) -> Option<PossibleScanMatch> {
+    fn has_possible_utf16_match(&self, index: u64) -> Option<PossibleScanMatch> {
         if index >= self.before_utf16 {
             Some(PossibleScanMatch::new(
                 self.name,
@@ -956,7 +956,7 @@ impl Scan {
 
         for def in &self.utf8_lanes[lane] {
             if def.packed_utf8 == packed_utf8 {
-                if let Some(possible_match) = def.possible_utf8_match(self.index) {
+                if let Some(possible_match) = def.has_possible_utf8_match(self.index) {
                     self.checks.push(possible_match);
                 }
                 break;
@@ -972,7 +972,7 @@ impl Scan {
 
         for def in &self.utf16_lanes[lane] {
             if def.packed_utf16 == packed_utf16 {
-                if let Some(possible_match) = def.possible_utf16_match(self.index) {
+                if let Some(possible_match) = def.has_possible_utf16_match(self.index) {
                     self.checks.push(possible_match);
                 }
                 break;

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -836,7 +836,7 @@ impl SecretMasker {
 
         let input_as_bytes = input.as_bytes();
         self.scan.parse_bytes(input_as_bytes);
-
+        
         let detections = self.scan.possible_matches();
 
         // Short-circuit if nothing to replace.


### PR DESCRIPTION
I saw some opportunity to microbenchmark and somewhat improve this code.

Reported perf goes from ~150ns per iteration to ~120ns per iteration on my machine, in release mode.

I've tried to keep the API the same. It may be worthwhile to expose some additional parts of the code to make reuse of the `ScanData` and/or `ScanState` easier in downstream projects, but I've decided not to do any of that in this PR.

~~I seem to also have applied `rustfmt` to the file. Hope that that's OK.~~