### PR TITLE
Rust: Fix benchmark performance test

### DIFF
--- a/src/security_utilities_rust/src/end_to_end_tests.rs
+++ b/src/security_utilities_rust/src/end_to_end_tests.rs
@@ -60,6 +60,7 @@ fn identifiable_scanning_and_validation_perf_benchmark() {
 
         let generated_input = valid_key.clone().unwrap();
         let input_as_bytes = generated_input.as_bytes();
+        scan.reset();
 
         let start = Instant::now();
         scan.parse_bytes(input_as_bytes);


### PR DESCRIPTION
The current benchmark test for the Rust scanner omitted the scanner getting reset. This causes the scanner to accumulate possible matches and cause the Vec to resize. This leads to an inaccurate picture of performance of the scanner.

By properly resetting the scanner, the performance increases by ~20%.