### PR TITLE
Optimize secret masking, c3id genertion, `marvin`, and checksum validation.

### DIFF
--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -30,7 +30,13 @@ fn secret_masker_test() {
         scan:  microsoft_security_utilities_core::identifiable_scans::Scan::new(options)
     };
 
-    for _ in 0..1000 {
+    #[cfg(debug_assertions)]
+    let iterations = 1000;
+
+    #[cfg(not(debug_assertions))]
+    let iterations = 500_000;
+
+    for _ in 0..iterations {
         // generate a key
         let valid_key = microsoft_security_utilities_core::identifiable_secrets::
         generate_common_annotated_key(

--- a/src/security_utilities_rust/src/identifiable_secrets_tests.rs
+++ b/src/security_utilities_rust/src/identifiable_secrets_tests.rs
@@ -239,11 +239,16 @@ fn identifiable_secrets_compute_checksum_seed_enforces_length_requirement()
     {
         let literal = "A".repeat(i) + "0";
 
-        let result = std::panic::catch_unwind(|| microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(&literal));
+        let result =
+            std::panic::catch_unwind(|| microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(&literal));
+        let array_result = literal.as_bytes().try_into().ok().and_then(microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed_from_array);
+
+        assert!(result.is_ok() ==  array_result.is_some(), "Array result and result have differing success.");
 
         if i == 7 
         {
             assert!(result.is_ok(), "literal '{}' should generate a valid seed", literal);
+            assert_eq!(result.unwrap(), array_result.unwrap(), "Result and array result are not equal.")
         } else 
         {
             assert!(result.is_err(), "literal '{}' should raise an exception as it's not the correct length", literal);
@@ -341,10 +346,17 @@ fn identifiable_secrets_compute_checksum_seed()
     let expected_checksum_seed2 = 0x5257536565643030;
 
     let checksum_seed1 = microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(input_literal1);
+    let checksum_seed1_array =
+        microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed_from_array(input_literal1.as_bytes().try_into().unwrap());
+
     let checksum_seed2 = microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed(input_literal2);
+    let checksum_seed2_array =
+        microsoft_security_utilities_core::identifiable_secrets::compute_his_v1_checksum_seed_from_array(input_literal2.as_bytes().try_into().unwrap());
 
     assert_eq!(checksum_seed1, expected_checksum_seed1);
+    assert_eq!(checksum_seed1, checksum_seed1_array.unwrap());
     assert_eq!(checksum_seed2, expected_checksum_seed2);
+    assert_eq!(checksum_seed2, checksum_seed2_array.unwrap());
 }
 
 #[test]

--- a/src/security_utilities_rust/src/marvin_tests.rs
+++ b/src/security_utilities_rust/src/marvin_tests.rs
@@ -7,7 +7,9 @@
 #![allow(unused_assignments)]
 
 use super::*;
-use microsoft_security_utilities_core::marvin::{compute_hash, compute_hash32};
+use microsoft_security_utilities_core::marvin::{
+    compute_hash, compute_hash32, compute_hash32_slice, compute_hash_slice,
+};
 
 /// Compare a Marvin checksum against a well-known test case from the native code.
 #[test]
@@ -45,15 +47,53 @@ fn marvin_longer_string() {
 
     // Act
     let marvin: i64 = compute_hash(&input, seed, 0, input.len() as i32);
+    let marvin_slice = compute_hash_slice(&input, seed);
 
     // Assert
+    assert_eq!(marvin, marvin_slice);
     assert_eq!(expected, marvin);
 }
 
+#[derive(Clone)]
 struct TestCase {
     seed: u64,
     text: Vec<u8>,
+    length: usize,
     checksum: u64,
+    offset: i32,
+}
+
+impl TestCase {
+    pub fn new<T>(seed: u64, checksum: u64, text: T) -> Self
+    where
+        T: AsRef<[u8]>,
+    {
+        Self {
+            seed,
+            checksum,
+            offset: 0,
+            text: text.as_ref().to_vec(),
+            length: text.as_ref().len(),
+        }
+    }
+
+    pub fn add_offset(&self, offset: i32) -> Self {
+        let mut text = vec![0u8; offset as usize];
+        text.extend_from_slice(&self.text);
+
+        Self {
+            seed: self.seed,
+            checksum: self.checksum,
+            text,
+            offset,
+            length: self.length,
+        }
+    }
+
+    pub fn add_byte_at_end(mut self) -> Self {
+        self.text.push(0);
+        self
+    }
 }
 
 /// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
@@ -61,11 +101,7 @@ struct TestCase {
 /// completely compliant/correct and so it should not be used. But the simple test
 /// cases here do result in matching output.
 /// https://github.com/skeeto/marvin32/blob/21020faea884799879492204af70414facfd27e9/marvin32.c#L112
-#[rustfmt::skip]
-fn create_test_cases() -> Vec<TestCase>
-{
-    let mut v: Vec<TestCase> = Vec::new();
-
+fn create_test_cases() -> Vec<TestCase> {
     // A random seed value used by the tests referenced below.
     let seed_0: u64 = 0x004fb61a001bdbcc;
 
@@ -75,41 +111,48 @@ fn create_test_cases() -> Vec<TestCase>
     // A random seed value used by the tests referenced below.
     let seed_2: u64 = 0x804fb61a801bdbcc;
 
-    // seed_0 testcases
-    v.push(TestCase { seed: seed_0, text: "".as_bytes().to_vec(),  checksum: 0x30ed35c100cd3c7d});
-    v.push(TestCase { seed: seed_0, text: [175].to_vec(), checksum: 0x48e73fc77d75ddc1});
-    v.push(TestCase { seed : seed_0, text : [231, 15].to_vec(),  checksum : 0xb5f6e1fc485dbff8});
-    v.push(TestCase { seed : seed_0, text : [55, 244, 149].to_vec(),  checksum : 0xf0b07c789b8cf7e8});
-    v.push(TestCase { seed : seed_0, text : [134, 66, 220, 89].to_vec(),  checksum : 0x7008f2e87e9cf556});
-    v.push(TestCase { seed : seed_0, text : [21, 63, 183, 152, 38].to_vec(),  checksum : 0xe6c08c6da2afa997});
-    v.push(TestCase { seed : seed_0, text : [9, 50, 230, 36, 108, 71].to_vec(),  checksum :0x6f04bf1a5ea24060});
-    v.push(TestCase { seed : seed_0, text : [171, 66, 126, 168, 209, 15, 199].to_vec(),  checksum : 0xe11847e4f0678c41});
+    #[rustfmt::skip]
+    let v = vec![
+        // seed_0 test cases
+        TestCase::new(seed_0, 0x30ed35c100cd3c7d, b"",),
+        TestCase::new(seed_0, 0x48e73fc77d75ddc1, [175]),
+        TestCase::new(seed_0, 0xb5f6e1fc485dbff8, [231, 15]),
+        TestCase::new(seed_0, 0xf0b07c789b8cf7e8, [55, 244, 149]),
+        TestCase::new(seed_0, 0x7008f2e87e9cf556,[134, 66, 220, 89]),
+        TestCase::new(seed_0, 0xe6c08c6da2afa997,[21, 63, 183, 152, 38]),
+        TestCase::new(seed_0, 0x6f04bf1a5ea24060, [9, 50, 230, 36, 108, 71]),
+        TestCase::new(seed_0, 0xe11847e4f0678c41, [171, 66, 126, 168, 209, 15, 199]),
 
-    // seed_1 testcases
-    v.push(TestCase { seed : seed_1, text : "".as_bytes().to_vec(),  checksum : 0x10a9d5d3996fd65d});
-    v.push(TestCase { seed : seed_1, text : [175].to_vec(), checksum : 0x68201f91960ebf91});
-    v.push(TestCase { seed : seed_1, text : [231, 15].to_vec(),  checksum : 0x64b581631f6ab378});
-    v.push(TestCase { seed : seed_1, text : [55, 244, 149].to_vec(),  checksum : 0xe1f2dfa6e5131408});
-    v.push(TestCase { seed : seed_1, text : [134, 66, 220, 89].to_vec(),  checksum : 0x36289d9654fb49f6});
-    v.push(TestCase { seed : seed_1, text : [21, 63, 183, 152, 38].to_vec(),  checksum : 0x0a06114b13464dbd});
-    v.push(TestCase { seed : seed_1, text : [9, 50, 230, 36, 108, 71].to_vec(),  checksum : 0xd6dd5e40ad1bc2ed});
-    v.push(TestCase { seed : seed_1, text : [171, 66, 126, 168, 209, 15, 199].to_vec(),  checksum : 0xe203987dba252fb3});
+        TestCase::new(seed_1,  0x10a9d5d3996fd65d, ""),
+        TestCase::new(seed_1, 0x68201f91960ebf91, [175]),
+        TestCase::new(seed_1, 0x64b581631f6ab378, [231, 15]),
+        TestCase::new(seed_1, 0xe1f2dfa6e5131408, [55, 244, 149]),
+        TestCase::new(seed_1, 0x36289d9654fb49f6, [134, 66, 220, 89]),
+        TestCase::new(seed_1, 0x0a06114b13464dbd, [21, 63, 183, 152, 38]),
+        TestCase::new(seed_1, 0xd6dd5e40ad1bc2ed, [9, 50, 230, 36, 108, 71]),
+        TestCase::new(seed_1, 0xe203987dba252fb3, [171, 66, 126, 168, 209, 15, 199]),
 
-    // seed_2 testcases
-    v.push( TestCase { seed : seed_2, text : [0].to_vec(),  checksum : 0xa37fb0da2ecae06c});
-    v.push( TestCase { seed : seed_2, text : [255].to_vec(),  checksum : 0xfecef370701ae054});
-    v.push( TestCase { seed : seed_2, text : [0, 255].to_vec(),  checksum : 0xa638e75700048880});
-    v.push( TestCase { seed : seed_2, text : [255, 0].to_vec(),  checksum : 0xbdfb46d969730e2a});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255].to_vec(),  checksum : 0x9d8577c0fe0d30bf});
-    v.push( TestCase { seed : seed_2, text : [0,255, 0].to_vec(),  checksum : 0x4f9fbdde15099497});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255].to_vec(),  checksum : 0x24eaa279d9a529ca});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0].to_vec(),  checksum : 0xd3bec7726b057943});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255].to_vec(),  checksum : 0x920b62bbca3e0b72});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0].to_vec(),  checksum : 0x1d7ddf9dfdf3c1bf});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0, 255].to_vec(),  checksum : 0xec21276a17e821a5});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255, 0].to_vec(),  checksum : 0x6911a53ca8c12254});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255, 0, 255].to_vec(),  checksum : 0xfdfd187b1d3ce784});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0, 255, 0].to_vec(),  checksum : 0x71876f2efb1b0ee8});
+        TestCase::new(seed_2, 0xa37fb0da2ecae06c, [0]),
+        TestCase::new(seed_2, 0xfecef370701ae054, [255]),
+        TestCase::new(seed_2, 0xa638e75700048880, [0, 255]),
+        TestCase::new(seed_2, 0xbdfb46d969730e2a, [255, 0]),
+        TestCase::new(seed_2, 0x9d8577c0fe0d30bf, [255, 0, 255]),
+        TestCase::new(seed_2, 0x4f9fbdde15099497, [0,255, 0]),
+        TestCase::new(seed_2, 0x24eaa279d9a529ca, [0, 255, 0, 255]),
+        TestCase::new(seed_2, 0xd3bec7726b057943, [255, 0, 255, 0]),
+        TestCase::new(seed_2, 0x920b62bbca3e0b72, [255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x1d7ddf9dfdf3c1bf, [0, 255, 0, 255, 0]),
+        TestCase::new(seed_2, 0xec21276a17e821a5, [0, 255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x6911a53ca8c12254, [255, 0, 255, 0, 255, 0]),
+        TestCase::new(seed_2, 0xfdfd187b1d3ce784, [255, 0, 255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x71876f2efb1b0ee8, [0, 255, 0, 255, 0, 255, 0]),
+    ];
+
+    // Generate offsets
+    let v = v
+        .iter()
+        .flat_map(|v| [0, 1, 5, 100].map(|o| v.add_offset(o).add_byte_at_end()))
+        .collect();
 
     return v;
 }
@@ -124,13 +167,21 @@ fn marvin_various_cases() {
         let seed = testcase.seed;
         let expected64: i64 = testcase.checksum as i64;
         let expected32: i32 = (expected64 ^ expected64 >> 32) as i32;
+        let offset = testcase.offset;
 
         // Act
-        let marvin64 = compute_hash(input, seed, 0, input.len() as i32);
-        let marvin32: i32 = compute_hash32(input, seed, 0, input.len() as i32);
+        let marvin64 = compute_hash(input, seed, offset, testcase.length as i32);
+        let marvin32: i32 = compute_hash32(input, seed, offset, testcase.length as i32);
+
+        let offsetu = offset as usize;
+        let marvin64_slice = compute_hash_slice(&input[offsetu..(offsetu + testcase.length)], seed);
+        let marvin32_slice =
+            compute_hash32_slice(&input[offsetu..(offsetu + testcase.length)], seed);
 
         // Assert
+        assert_eq!(marvin64, marvin64_slice);
         assert_eq!(expected64, marvin64);
+        assert_eq!(marvin32, marvin32_slice);
         assert_eq!(expected32, marvin32);
     }
 }

--- a/src/security_utilities_rust/src/marvin_tests.rs
+++ b/src/security_utilities_rust/src/marvin_tests.rs
@@ -7,6 +7,7 @@
 #![allow(unused_assignments)]
 
 use super::*;
+use microsoft_security_utilities_core::marvin::{compute_hash, compute_hash32};
 
 /// Compare a Marvin checksum against a well-known test case from the native code.
 #[test]
@@ -14,7 +15,7 @@ fn marvin_basic() {
     // This test verifies that our Rust implementation provides
     // the same result as SymCrypt for their standard test.
     // https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c#L316
-    
+
     // Assume
     let seed: u64 = 0xd53cd9cecd0893b7;
     let v: Vec<u8> = String::from("abc").into_bytes();
@@ -22,8 +23,8 @@ fn marvin_basic() {
     let expected: i64 = 0x22c74339492769bf;
 
     // Act
-    let marvin: i64 = microsoft_security_utilities_core::marvin::compute_hash(&input, seed, 0, input.len() as i32);
-    
+    let marvin: i64 = compute_hash(&input, seed, 0, input.len() as i32);
+
     // Assert
     assert_eq!(expected, marvin);
 }
@@ -31,12 +32,11 @@ fn marvin_basic() {
 /// Compare a Marvin checksum against a well-known test case from the native code.
 #[test]
 #[allow(overflowing_literals)]
-fn marvin_longer_string()
-{
+fn marvin_longer_string() {
     // This test verifies that our C# implementation provides
     // the same result as SymCrypt for their standard test.
     // https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c#L316
-    
+
     // Assume
     let seed: u64 = 0xddddeeeeffff000;
     let v: Vec<u8> = String::from("abcdefghijklmnopqrstuvwxyz").into_bytes();
@@ -44,7 +44,7 @@ fn marvin_longer_string()
     let expected: i64 = 0xa128eb7e7260aca2;
 
     // Act
-    let marvin: i64 = microsoft_security_utilities_core::marvin::compute_hash(&input, seed, 0, input.len() as i32);
+    let marvin: i64 = compute_hash(&input, seed, 0, input.len() as i32);
 
     // Assert
     assert_eq!(expected, marvin);
@@ -53,14 +53,15 @@ fn marvin_longer_string()
 struct TestCase {
     seed: u64,
     text: Vec<u8>,
-    checksum: u64
+    checksum: u64,
 }
 
-    /// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
+/// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
 /// Marvin32 implementation. This implementation, per Niels Ferguson is not considered
 /// completely compliant/correct and so it should not be used. But the simple test
 /// cases here do result in matching output.
 /// https://github.com/skeeto/marvin32/blob/21020faea884799879492204af70414facfd27e9/marvin32.c#L112
+#[rustfmt::skip]
 fn create_test_cases() -> Vec<TestCase>
 {
     let mut v: Vec<TestCase> = Vec::new();
@@ -114,12 +115,10 @@ fn create_test_cases() -> Vec<TestCase>
 }
 
 #[test]
-fn marvin_various_cases()
-{
+fn marvin_various_cases() {
     let testcases = create_test_cases();
 
-    for testcase in testcases 
-    {
+    for testcase in testcases {
         // Assume
         let input: &[u8] = &(testcase.text);
         let seed = testcase.seed;
@@ -127,8 +126,8 @@ fn marvin_various_cases()
         let expected32: i32 = (expected64 ^ expected64 >> 32) as i32;
 
         // Act
-        let marvin64 = microsoft_security_utilities_core::marvin::compute_hash(input, seed, 0, input.len() as i32);
-        let marvin32: i32 = microsoft_security_utilities_core::marvin::compute_hash32(input, seed, 0, input.len() as i32);
+        let marvin64 = compute_hash(input, seed, 0, input.len() as i32);
+        let marvin32: i32 = compute_hash32(input, seed, 0, input.len() as i32);
 
         // Assert
         assert_eq!(expected64, marvin64);
@@ -138,32 +137,28 @@ fn marvin_various_cases()
 
 #[test]
 #[should_panic]
-fn marvin_compute_hash_panic_if_invalid_args_1()
-{
+fn marvin_compute_hash_panic_if_invalid_args_1() {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, -1, 0);
+    compute_hash(input, 0, -1, 0);
 }
 
 #[test]
 #[should_panic]
-fn marvin_compute_hash_panic_if_invalid_args_2()
-{
+fn marvin_compute_hash_panic_if_invalid_args_2() {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 5, 0);
+    compute_hash(input, 0, 5, 0);
 }
 
 #[test]
 #[should_panic]
-fn marvin_compute_hash_panic_if_invalid_args_3()
-{
+fn marvin_compute_hash_panic_if_invalid_args_3() {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 1, -1);
+    compute_hash(input, 0, 1, -1);
 }
 
 #[test]
 #[should_panic]
-fn marvin_compute_hash_panic_if_invalid_args_4()
-{
+fn marvin_compute_hash_panic_if_invalid_args_4() {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 3, 3);
+    compute_hash(input, 0, 3, 3);
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use sha2::{Sha256, Digest};
-use std::fmt;
+use sha2::{Digest, Sha256};
 use std::cell::RefCell;
+use std::fmt::Write;
 
 thread_local! {
     static THREAD_LOCAL_SHA256: RefCell<Sha256> = RefCell::new(Sha256::new());
@@ -13,23 +13,25 @@ thread_local! {
 pub fn generate_cross_company_correlating_id(text: &str) -> String {
     let hash = generate_sha256_hash(text);
 
-    let hash = format!("CrossMicrosoftCorrelatingId:{}", hash);
-
     let checksum = THREAD_LOCAL_SHA256.with(|sha| {
-        sha.borrow_mut().update(hash.as_bytes());
-        sha.borrow_mut().finalize_reset()
+        let mut sha = sha.borrow_mut();
+
+        sha.update("CrossMicrosoftCorrelatingId:");
+        sha.update(hash);
+        sha.finalize_reset()
     });
 
     let to_encode = &checksum[0..15];
     STANDARD.encode(to_encode)
 }
 
-pub fn generate_sha256_hash(text: &str) -> String {
-
+fn generate_sha256_hash(text: &str) -> String {
     let result = THREAD_LOCAL_SHA256.with(|sha| {
         sha.borrow_mut().update(text.as_bytes());
         sha.borrow_mut().finalize_reset()
     });
 
-    fmt::format(format_args!("{:X}", result))
+    let mut output = String::with_capacity(2 * 32);
+    write!(output, "{:X}", result).unwrap();
+    output
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -857,7 +857,7 @@ impl SecretMasker {
 
             if validate_checksum {
                 let match_text_as_bytes = match_text.as_bytes();
-                let mut signature_bytes = vec![0; 3];
+                let mut signature_bytes = [0; 3];
                 signature_bytes[0] = match_text_as_bytes[57];
                 signature_bytes[1] = match_text_as_bytes[58];
                 signature_bytes[2] = match_text_as_bytes[59];

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -103,10 +103,6 @@ pub fn is_base64_url_encoding_char(ch: char) -> bool
 
 // TODO: change return type to Result<bool, String>?
 pub fn try_validate_common_annotated_key(key: &str, base64_encoded_signature: &str) -> bool {
-    if key.is_empty() || key.trim().is_empty() {
-        return false;
-    }
-
     if let Err(e) = validate_common_annotated_key_signature(base64_encoded_signature) {
         println!("{}", e);
         return false;

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -21,11 +21,15 @@ use substring::Substring;
 use crate::microsoft_security_utilities_core;
 use crate::microsoft_security_utilities_core::identifiable_scans::PossibleScanMatch;
 
-lazy_static! {
-    pub static ref VERSION_TWO_CHECKSUM_SEED: u64 = compute_his_v1_checksum_seed("Default0");
-}
+pub const VERSION_TWO_CHECKSUM_SEED: u64 = {
+    // TODO: Option::unwrap is not const yet
+    if let Some(v) = compute_his_v1_checksum_seed_from_array(b"Default0") {
+        v
+    } else {
+        panic!("Generating V2 checksum seed failed.");
+    }};
 
-pub static COMMON_ANNOTATED_KEY_REGEX_PATTERN: &str = r"(?-i)[A-Za-z0-9]{52}JQQJ9(9|D)[A-Za-z0-9][A-L][A-Za-z0-9]{16}[A-Za-z][A-Za-z0-9]{7}([A-Za-z0-9]{2}==)?";
+pub const COMMON_ANNOTATED_KEY_REGEX_PATTERN: &str = r"(?-i)[A-Za-z0-9]{52}JQQJ9(9|D)[A-Za-z0-9][A-L][A-Za-z0-9]{16}[A-Za-z][A-Za-z0-9]{7}([A-Za-z0-9]{2}==)?";
 
 lazy_static! {
     pub static ref COMMON_ANNOTATED_KEY_REGEX: Regex = Regex::new(COMMON_ANNOTATED_KEY_REGEX_PATTERN).unwrap();
@@ -116,14 +120,13 @@ pub fn try_validate_common_annotated_key(key: &str, base64_encoded_signature: &s
 
     let long_form = key.len() == LONG_FORM_COMMON_ANNOTATED_KEY_SIZE;
 
-    let checksum_seed = VERSION_TWO_CHECKSUM_SEED.clone();
     let checksum_len = if long_form { 4 } else { 3 };
 
     let component_data = general_purpose::STANDARD.decode(key).unwrap();
     let key_bytes = &component_data[..component_data.len() - checksum_len];
     let input_checksum_bytes = &component_data[component_data.len() - checksum_len..];
 
-    let checksum = marvin::compute_hash32(&key_bytes, checksum_seed, 0, key_bytes.len() as i32);
+    let checksum = marvin::compute_hash32(&key_bytes, VERSION_TWO_CHECKSUM_SEED, 0, key_bytes.len() as i32);
 
     let checksum_bytes = checksum.to_ne_bytes();
 
@@ -152,17 +155,52 @@ pub fn try_validate_common_annotated_key(key: &str, base64_encoded_signature: &s
 ///
 /// # Errors
 ///
-/// This function will return an error if the `versioned_key_kind` does not meet the required criteria.
+/// This function will panic if the `versioned_key_kind` does not meet the required criteria.
 pub fn compute_his_v1_checksum_seed(versioned_key_kind: &str) -> u64 {
 
-    if versioned_key_kind.len() != 8 || !versioned_key_kind.chars().nth(7).unwrap().is_digit(10) {
-        panic!("The versioned literal must be 8 characters long and end with a digit.");
+    if versioned_key_kind.len() != 8 {
+        panic!("The versioned literal must be 8 characters long.");
     }
 
-    let bytes = versioned_key_kind.as_bytes().iter().rev().cloned().collect::<Vec<u8>>();
-    let result = u64::from_le_bytes(bytes.try_into().unwrap());
+    let bytes: [u8; 8] = versioned_key_kind.as_bytes().try_into().unwrap();
 
-    result
+    compute_his_v1_checksum_seed_from_array(&bytes).unwrap()
+}
+
+/// Generate a u64 an HIS v1 compliant checksum seed from a literal byte array
+/// that is 8 characters long and ends with at least one digit, e.g., 'ReadKey0', 'RWSeed00',
+/// etc. The checksum seed is used to initialize the Marvin32 algorithm to watermark a
+/// specific class of generated security keys.
+///
+/// # Arguments
+///
+/// * `versioned_key_kind` - An ASCII-encoded name that identifies a specific set of generated keys with at least one trailing digit in the name.
+///
+/// # Returns
+///
+/// The computed checksum seed as a u64.
+///
+/// # Errors
+///
+/// This function return `None` if the last character of the array is not in the range '0'..'9' (ASCII)
+pub const fn compute_his_v1_checksum_seed_from_array(versioned_key_kind: &[u8; 8]) -> Option<u64> {
+
+    if versioned_key_kind[7] < b'0' || versioned_key_kind[7] > b'9' {
+        return None;
+    }
+
+    let mut count = 8;
+    let mut output = [0u8; 8];
+    loop {
+        if count == 0 {
+            break;
+        }
+        let idx = count - 1;
+        output[idx] = versioned_key_kind[7 - idx];
+        count -= 1;
+    }
+
+    Some(u64::from_le_bytes(output))
 }
 
 pub fn generate_common_annotated_key(base64_encoded_signature: &str,

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -130,7 +130,7 @@ pub fn try_validate_common_annotated_key_valid_signature(key: &str) -> bool {
     let key_bytes = &component_data[..component_data.len() - checksum_len];
     let input_checksum_bytes = &component_data[component_data.len() - checksum_len..];
 
-    let checksum = marvin::compute_hash32(&key_bytes, VERSION_TWO_CHECKSUM_SEED, 0, key_bytes.len() as i32);
+    let checksum = marvin::compute_hash32_slice(&key_bytes, VERSION_TWO_CHECKSUM_SEED);
 
     let checksum_bytes = checksum.to_ne_bytes();
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -121,7 +121,12 @@ pub fn try_validate_common_annotated_key_valid_signature(key: &str) -> bool {
         return false;
     };
 
-    let component_data = general_purpose::STANDARD.decode(key).unwrap();
+    let component_data = if let Ok(value) = general_purpose::STANDARD.decode(key) {
+        value
+    } else {
+        return false;
+    };
+
     let key_bytes = &component_data[..component_data.len() - checksum_len];
     let input_checksum_bytes = &component_data[component_data.len() - checksum_len..];
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -101,6 +101,7 @@ pub fn is_base64_url_encoding_char(ch: char) -> bool
                    ch == '_';
 }
 
+// TODO: change return type to Result<bool, String>?
 pub fn try_validate_common_annotated_key(key: &str, base64_encoded_signature: &str) -> bool {
     if key.is_empty() || key.trim().is_empty() {
         return false;
@@ -111,6 +112,10 @@ pub fn try_validate_common_annotated_key(key: &str, base64_encoded_signature: &s
         return false;
     }
 
+    try_validate_common_annotated_key_valid_signature(key)
+}
+
+pub fn try_validate_common_annotated_key_valid_signature(key: &str) -> bool {
     // A long-form has a full 4-byte checksum, while a standard form has only 3.
     let checksum_len = if key.len() == STANDARD_COMMON_ANNOTATED_KEY_SIZE {
         3
@@ -899,20 +904,29 @@ impl SecretMasker {
             let match_text = scan_match.text();
 
             if validate_checksum {
-                let match_text_as_bytes = match_text.as_bytes();
-                let mut signature_bytes = [0; 3];
-                signature_bytes[0] = match_text_as_bytes[57];
-                signature_bytes[1] = match_text_as_bytes[58];
-                signature_bytes[2] = match_text_as_bytes[59];
+                let checksum_validation_result =
+                    try_validate_common_annotated_key_valid_signature(&match_text);
 
-                let signature = general_purpose::STANDARD.encode(&signature_bytes);
+                if !checksum_validation_result {
+                    let match_text_as_bytes = match_text.as_bytes();
+                    let mut signature_bytes = [0; 3];
+                    signature_bytes[0] = match_text_as_bytes[57];
+                    signature_bytes[1] = match_text_as_bytes[58];
+                    signature_bytes[2] = match_text_as_bytes[59];
 
-                let checksum_validation_result = try_validate_common_annotated_key(
-                    &match_text,
-                    &signature,
-                );
+                    let signature = general_purpose::STANDARD.encode(&signature_bytes);
 
-                assert!(checksum_validation_result);
+                    if let Err(e) =
+                        validate_common_annotated_key_signature(&signature)
+                    {
+                        println!("{}", e);
+                        return false;
+                    }
+
+                    // TODO: return false? Panics make it difficult to use this function
+                    // repeatedly.
+                    panic!("Checksum validation failed.");
+                }
             }
 
             let redaction_token = match default_redaction_token {

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -35,53 +35,53 @@ lazy_static! {
     pub static ref COMMON_ANNOTATED_KEY_REGEX: Regex = Regex::new(COMMON_ANNOTATED_KEY_REGEX_PATTERN).unwrap();
     }
 
-pub static MAXIMUM_GENERATED_KEY_SIZE: u32 = 4096;
-pub static MINIMUM_GENERATED_KEY_SIZE: u32 = 24;
-pub static STANDARD_COMMON_ANNOTATED_KEY_SIZE: usize = 84;
-pub static LONG_FORM_COMMON_ANNOTATED_KEY_SIZE: usize = 88;
-pub static COMMON_ANNOTATED_KEY_SIGNATURE: &str = "JQQJ99";
-pub static COMMON_ANNOTATED_DERIVED_KEY_SIGNATURE: &str = "JQQJ9D";
-static BITS_IN_BYTES: i32 = 8;
-static BITS_IN_BASE64_CHARACTER: i32 = 6;
-static SIZE_OF_CHECKSUM_IN_BYTES: i32 = mem::size_of::<u32>() as i32;
+pub const MAXIMUM_GENERATED_KEY_SIZE: u32 = 4096;
+pub const MINIMUM_GENERATED_KEY_SIZE: u32 = 24;
+pub const STANDARD_COMMON_ANNOTATED_KEY_SIZE: usize = 84;
+pub const LONG_FORM_COMMON_ANNOTATED_KEY_SIZE: usize = 88;
+pub const COMMON_ANNOTATED_KEY_SIGNATURE: &str = "JQQJ99";
+pub const COMMON_ANNOTATED_DERIVED_KEY_SIGNATURE: &str = "JQQJ9D";
+const BITS_IN_BYTES: i32 = 8;
+const BITS_IN_BASE64_CHARACTER: i32 = 6;
+const SIZE_OF_CHECKSUM_IN_BYTES: i32 = mem::size_of::<u32>() as i32;
 
-static COMMON_ANNOTATED_KEY_SIZE_IN_BYTES: usize = 63;
+const COMMON_ANNOTATED_KEY_SIZE_IN_BYTES: usize = 63;
 
 /// The offset to the encoded standard fixed signature ('JQQJ99' or 'JQQJ9D').
-pub static STANDARD_FIXED_SIGNATURE_OFFSET: usize = 52;
+pub const STANDARD_FIXED_SIGNATURE_OFFSET: usize = 52;
 
 /// The encoded length of the standard fixed signature ('JQQJ99' or 'JQQJ9D').
-pub static STANDARD_FIXED_SIGNATURE_LENGTH: usize = 6;
+pub const STANDARD_FIXED_SIGNATURE_LENGTH: usize = 6;
 
 /// The offset to the encoded character that denotes a derived ('D')
 /// or standard ('9') common annotated security key.
-pub static DERIVED_KEY_CHARACTER_OFFSET: usize = STANDARD_FIXED_SIGNATURE_OFFSET + STANDARD_FIXED_SIGNATURE_LENGTH - 1;
+pub const DERIVED_KEY_CHARACTER_OFFSET: usize = STANDARD_FIXED_SIGNATURE_OFFSET + STANDARD_FIXED_SIGNATURE_LENGTH - 1;
 
 /// The offset to the two-character encoded key creation date.
-pub static DATE_OFFSET: usize = STANDARD_FIXED_SIGNATURE_OFFSET + STANDARD_FIXED_SIGNATURE_LENGTH;
+pub const DATE_OFFSET: usize = STANDARD_FIXED_SIGNATURE_OFFSET + STANDARD_FIXED_SIGNATURE_LENGTH;
 
 /// The encoded length of the creation date (a value such as 'AE').
-pub static DATE_LENGTH: usize = 2;
+pub const DATE_LENGTH: usize = 2;
 
 /// The offset to the 12-character encoded platform-reserved data.
-pub static PLATFORM_RESERVED_OFFSET: usize = DATE_OFFSET + DATE_LENGTH;
+pub const PLATFORM_RESERVED_OFFSET: usize = DATE_OFFSET + DATE_LENGTH;
 
 /// The encoded length of the platform-reserved bytes.
-pub static PLATFORM_RESERVED_LENGTH: usize = 12;
+pub const PLATFORM_RESERVED_LENGTH: usize = 12;
 
 /// The offset to the 4-character encoded provider-reserved data.
-pub static PROVIDER_RESERVED_OFFSET: usize = PLATFORM_RESERVED_OFFSET + PLATFORM_RESERVED_LENGTH;
+pub const PROVIDER_RESERVED_OFFSET: usize = PLATFORM_RESERVED_OFFSET + PLATFORM_RESERVED_LENGTH;
 
 /// The encoded length of the provider-reserved bytes.
-pub static PROVIDER_RESERVED_LENGTH: usize = 4;
+pub const PROVIDER_RESERVED_LENGTH: usize = 4;
 
 /// The offset to the 4-character encoded provider fixed signature.
-pub static PROVIDER_FIXED_SIGNATURE_OFFSET: usize = PROVIDER_RESERVED_OFFSET + PROVIDER_RESERVED_LENGTH;
+pub const PROVIDER_FIXED_SIGNATURE_OFFSET: usize = PROVIDER_RESERVED_OFFSET + PROVIDER_RESERVED_LENGTH;
 
 /// The encoded length of the provider fixed signature, e.g., 'AZEG'.
-pub static PROVIDER_FIXED_SIGNATURE_LENGTH: usize = 4;
+pub const PROVIDER_FIXED_SIGNATURE_LENGTH: usize = 4;
 
-pub static CHECKSUM_OFFSET: usize = PROVIDER_FIXED_SIGNATURE_OFFSET + PROVIDER_FIXED_SIGNATURE_LENGTH;
+pub const CHECKSUM_OFFSET: usize = PROVIDER_FIXED_SIGNATURE_OFFSET + PROVIDER_FIXED_SIGNATURE_LENGTH;
 
 pub fn is_base62_encoding_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric()

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
@@ -3,20 +3,23 @@
 
 /// This is a Rust implementation of the Marvin32 checksum algorithm, the definitive native code for which is
 /// at https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c.
-use std::mem;
 
 /// Convenience method to compute a Marvin hash and collapse it into a 32-bit hash.
 pub fn compute_hash32(data: &[u8], seed: u64, offset: i32, length: i32) -> i32 {
-    let hash64: i64 = compute_hash(data, seed, offset, length);
+    let hash64 = compute_hash(data, seed, offset, length);
     return ((hash64 >> 32) as i32) ^ (hash64 as i32);
 }
 
-/// Computes a 64-bit hash using the Marvin algorithm.
-pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64 {
-    // Marvin by design can produce a checksum for empty input buffers, which
-    // is why it's ok for the offset to point just past the end of the buffer
-    // or for the input buffer to be empty;
-    if offset < 0 || offset > data.len() as i32 {
+/// Convenience method to compute a Marvin hash from a slice and collapse it into a 32-bit hash.
+pub fn compute_hash32_slice(data: &[u8], seed: u64) -> i32 {
+    let hash64 = compute_hash_slice(data, seed);
+    return ((hash64 >> 32) as i32) ^ (hash64 as i32);
+}
+
+/// Computes a 64-bit hash using the Marvin algorithm from the given slice,
+/// using the provided length and offset to determine the data to hash.
+pub fn compute_hash(data: &[u8], seed: u64, offset: i32, length: i32) -> i64 {
+    if offset > data.len() as i32 {
         panic!("Offset '{}' is out of range", offset);
     }
 
@@ -33,80 +36,65 @@ pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
         );
     }
 
-    let mut p0: u32 = seed as u32;
-    let mut p1: u32 = (seed >> 32) as u32;
+    let data = &data[offset as usize..(offset + length) as usize];
+    compute_hash_slice(data, seed)
+}
 
-    let mut remaining_data_offset: i32 = 0;
+/// Computes a 64-bit hash using the Marvin algorithm from a slice.
+pub fn compute_hash_slice(data: &[u8], seed: u64) -> i64 {
+    let mut p0 = seed as u32;
+    let mut p1 = (seed >> 32) as u32;
 
-    let uint_count = length / 4;
+    let mut chunks = data.chunks_exact(4);
 
-    if length as usize >= mem::size_of::<u32>() {
-        let mut index: i32 = 0 + offset;
+    for chunk in &mut chunks {
+        let u32_value = u32::from_le_bytes(chunk.try_into().expect("A slice of exactly 4 bytes"));
+        p0 = p0.wrapping_add(u32_value);
 
-        for _i in 0..uint_count {
-            let d3: u32 = (data[(index + 3) as usize] as u32) << 24;
-            let d2: u32 = (data[(index + 2) as usize] as u32) << 16;
-            let d1: u32 = (data[(index + 1) as usize] as u32) << 8;
-            let d0: u32 = data[(index + 0) as usize] as u32;
-            p0 = p0.wrapping_add(d3 | d2 | d1 | d0);
-
-            block(&mut p0, &mut p1);
-            index += 4;
-        }
-
-        remaining_data_offset = length & (!3);
-        length -= remaining_data_offset;
+        let (p0_new, p1_new) = block(p0, p1);
+        p0 = p0_new;
+        p1 = p1_new;
     }
 
-    remaining_data_offset += offset;
-
-    match length {
+    let remainder = chunks.remainder();
+    match remainder.len() {
         0 => p0 += 0x80,
-        1 => p0 = p0.wrapping_add(0x8000 | (data[remaining_data_offset as usize] as u32)),
+        1 => p0 = p0.wrapping_add(0x8000 | (remainder[0] as u32)),
         2 => {
-            let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
-            let d0: u32 = data[remaining_data_offset as usize] as u32;
+            let d1 = (remainder[1] as u32) << 8;
+            let d0 = remainder[0] as u32;
             p0 = p0.wrapping_add(0x800000 | d1 | d0);
         }
         3 => {
-            let d2 = (data[(remaining_data_offset as usize) + 2] as u32) << 16;
-            let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
-            let d0: u32 = data[remaining_data_offset as usize] as u32;
+            let d2 = (remainder[2] as u32) << 16;
+            let d1 = (remainder[1] as u32) << 8;
+            let d0 = remainder[0] as u32;
             p0 = p0.wrapping_add(0x80000000 | d2 | d1 | d0);
         }
-        _ => panic!("Hash computation reached an invalid state"),
+        _ => unreachable!("Hash computation reached an invalid state"),
     }
 
-    block(&mut p0, &mut p1);
-    block(&mut p0, &mut p1);
+    let (p0, p1) = block(p0, p1);
+    let (p0, p1) = block(p0, p1);
 
-    return (((p1 as i64) << 32) | (p0 as i64)) as i64;
+    return ((p1 as i64) << 32) | (p0 as i64);
 }
 
 /// Combines hash code of multiple objects while trying to minimize possibility of collisions.
 /// rp0: hash code seed.
 /// rp1: Delegates to generate hash codes to combine.
-fn block(rp0: &mut u32, rp1: &mut u32) {
-    let mut p0: u32 = *rp0;
-    let mut p1: u32 = *rp1;
-
+fn block(mut p0: u32, mut p1: u32) -> (u32, u32) {
     p1 = p1 ^ p0;
-    p0 = rotate(p0, 20);
+    p0 = p0.rotate_left(20);
 
     p0 = p0.wrapping_add(p1);
-    p1 = rotate(p1, 9);
+    p1 = p1.rotate_left(9);
 
     p1 = p1 ^ p0;
-    p0 = rotate(p0, 27);
+    p0 = p0.rotate_left(27);
 
     p0 = p0.wrapping_add(p1);
-    p1 = rotate(p1, 19);
+    p1 = p1.rotate_left(19);
 
-    *rp0 = p0;
-    *rp1 = p1;
-}
-
-/// Shift bits in an unsigned integer.
-fn rotate(value: u32, shift: i32) -> u32 {
-    (value << shift) | (value >> (32 - shift))
+    (p0, p1)
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
@@ -2,35 +2,35 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /// This is a Rust implementation of the Marvin32 checksum algorithm, the definitive native code for which is
-/// at https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c. 
+/// at https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c.
 use std::mem;
 
 /// Convenience method to compute a Marvin hash and collapse it into a 32-bit hash.
-pub fn compute_hash32(data: &[u8], seed: u64, offset: i32, length: i32) -> i32
-{
+pub fn compute_hash32(data: &[u8], seed: u64, offset: i32, length: i32) -> i32 {
     let hash64: i64 = compute_hash(data, seed, offset, length);
     return ((hash64 >> 32) as i32) ^ (hash64 as i32);
 }
 
 /// Computes a 64-bit hash using the Marvin algorithm.
-pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
-{
+pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64 {
     // Marvin by design can produce a checksum for empty input buffers, which
     // is why it's ok for the offset to point just past the end of the buffer
     // or for the input buffer to be empty;
-    if offset < 0 || offset > data.len() as i32
-    {
+    if offset < 0 || offset > data.len() as i32 {
         panic!("Offset '{}' is out of range", offset);
     }
 
-    if length < 0
-    {
+    if length < 0 {
         panic!("Length '{}' is out of range", length);
     }
 
-    if (offset + length) > data.len() as i32
-    {
-        panic!("Offset ({}) + length ({}) exceeds data length ({})", offset, length, data.len());
+    if (offset + length) > data.len() as i32 {
+        panic!(
+            "Offset ({}) + length ({}) exceeds data length ({})",
+            offset,
+            length,
+            data.len()
+        );
     }
 
     let mut p0: u32 = seed as u32;
@@ -40,12 +40,10 @@ pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
 
     let uint_count = length / 4;
 
-    if length as usize >= mem::size_of::<u32>()
-    {
+    if length as usize >= mem::size_of::<u32>() {
         let mut index: i32 = 0 + offset;
 
-        for _i in 0..uint_count
-        {
+        for _i in 0..uint_count {
             let d3: u32 = (data[(index + 3) as usize] as u32) << 24;
             let d2: u32 = (data[(index + 2) as usize] as u32) << 16;
             let d1: u32 = (data[(index + 1) as usize] as u32) << 8;
@@ -62,22 +60,21 @@ pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
 
     remaining_data_offset += offset;
 
-    match length
-    {
+    match length {
         0 => p0 += 0x80,
         1 => p0 = p0.wrapping_add(0x8000 | (data[remaining_data_offset as usize] as u32)),
         2 => {
             let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
             let d0: u32 = data[remaining_data_offset as usize] as u32;
             p0 = p0.wrapping_add(0x800000 | d1 | d0);
-        },
+        }
         3 => {
             let d2 = (data[(remaining_data_offset as usize) + 2] as u32) << 16;
             let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
             let d0: u32 = data[remaining_data_offset as usize] as u32;
             p0 = p0.wrapping_add(0x80000000 | d2 | d1 | d0);
-        },
-        _ => panic!("Hash computation reached an invalid state")
+        }
+        _ => panic!("Hash computation reached an invalid state"),
     }
 
     block(&mut p0, &mut p1);
@@ -86,11 +83,10 @@ pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
     return (((p1 as i64) << 32) | (p0 as i64)) as i64;
 }
 
-    /// Combines hash code of multiple objects while trying to minimize possibility of collisions.
-    /// rp0: hash code seed.
-    /// rp1: Delegates to generate hash codes to combine.
-fn block(rp0:&mut u32, rp1:&mut u32)
-{
+/// Combines hash code of multiple objects while trying to minimize possibility of collisions.
+/// rp0: hash code seed.
+/// rp1: Delegates to generate hash codes to combine.
+fn block(rp0: &mut u32, rp1: &mut u32) {
     let mut p0: u32 = *rp0;
     let mut p1: u32 = *rp1;
 
@@ -111,8 +107,6 @@ fn block(rp0:&mut u32, rp1:&mut u32)
 }
 
 /// Shift bits in an unsigned integer.
-fn rotate(value: u32, shift: i32) -> u32
-{
+fn rotate(value: u32, shift: i32) -> u32 {
     (value << shift) | (value >> (32 - shift))
 }
-    


### PR DESCRIPTION
This PR improves the `secret_masker_test`  with checksum benchmark by about 32%, from 1300 ns to 880 ns per iteration, and the without checksum by about 15% from 879ns to 734 ns per iteration, on my machine.

It applies the following changes:
* `marvin`
  * Made more idiomatic by relying on slices to provide us with lengths and offsets (~20% speedup). Updated existing impl to use that after validating slice constraints.
  * Applied `rustfmt`
  * Increased test coverage by adding offsets and non-full-length tests
* Cross company IDs
  * Decreased amount of work required by removing some unnecessary formatting calls and pre-allocating data for known-length strings.
* Secret masking
  * During validation, skip validating the correctness of the key: if it contains invalid bytes, the signature check will fail and we panic either way, so the error message is lost. If we do want this, we should add it as a "post" step, where we check the validity of the signature bytes in the case that validation fails and report it to the caller. It may be that I misunderstood the point of this check, so please do leave feedback in case it is necessary :)
  * Don't calculate the cross-company ID if we don't need it
  * Use the `last()` detection to track the current one instead of keeping separate state + cloning and unwrapping a bunch
* Scanning
  * API BREAKING (but functionality remains the same): `ScanMatch`: use `Cow<'a, str>` instead of `String` to avoid unnecessarily copying utf8 data to a new string.
* identifiable secrets
  * Make a bunch of `static`s `const`.
  * Remove checks that are expensive on the happy path and have minor perf improvement for the un-happy path, that are not explicitly reported.
  * Decrease amount of en- and decoding required for validating a key signature by re-using existing bytes.

This may be (far too) much for a single PR, but I have tried my best to split the changes into concise commits and am willing to make separate PRs for them if that is preferred.