### PR TITLE
Rust/c3id: Decrease allocations & formatting

### DIFF
--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use sha2::{Sha256, Digest};
-use std::fmt;
+use sha2::{Digest, Sha256};
 use std::cell::RefCell;
+use std::fmt::Write;
 
 thread_local! {
     static THREAD_LOCAL_SHA256: RefCell<Sha256> = RefCell::new(Sha256::new());
@@ -13,23 +13,25 @@ thread_local! {
 pub fn generate_cross_company_correlating_id(text: &str) -> String {
     let hash = generate_sha256_hash(text);
 
-    let hash = format!("CrossMicrosoftCorrelatingId:{}", hash);
-
     let checksum = THREAD_LOCAL_SHA256.with(|sha| {
-        sha.borrow_mut().update(hash.as_bytes());
-        sha.borrow_mut().finalize_reset()
+        let mut sha = sha.borrow_mut();
+
+        sha.update("CrossMicrosoftCorrelatingId:");
+        sha.update(hash);
+        sha.finalize_reset()
     });
 
     let to_encode = &checksum[0..15];
     STANDARD.encode(to_encode)
 }
 
-pub fn generate_sha256_hash(text: &str) -> String {
-
+fn generate_sha256_hash(text: &str) -> String {
     let result = THREAD_LOCAL_SHA256.with(|sha| {
         sha.borrow_mut().update(text.as_bytes());
         sha.borrow_mut().finalize_reset()
     });
 
-    fmt::format(format_args!("{:X}", result))
+    let mut output = String::with_capacity(2 * 32);
+    write!(output, "{:X}", result).unwrap();
+    output
 }


### PR DESCRIPTION
Reducing the amount of required allocations improves performance by about 20% for few-block computations (0 to 88 characters), and by about 6% for many block (1024 characters) due to reduced (re-)allocation overhead.

[Benchmark](https://github.com/datdenkikniet/security-utilities/blob/bench/src/security_utilities_rust/benches/cross_company_correlating_id.rs)