### PR TITLE
Rust/Marvin: add slice-only functions

### DIFF
--- a/src/security_utilities_rust/src/marvin_tests.rs
+++ b/src/security_utilities_rust/src/marvin_tests.rs
@@ -45,9 +45,11 @@ fn marvin_longer_string()
 
     // Act
     let marvin: i64 = microsoft_security_utilities_core::marvin::compute_hash(&input, seed, 0, input.len() as i32);
+    let marvin_slice = microsoft_security_utilities_core::marvin::compute_hash_slice(&input, seed);
 
     // Assert
     assert_eq!(expected, marvin);
+    assert_eq!(marvin, marvin_slice);
 }
 
 struct TestCase {
@@ -56,7 +58,7 @@ struct TestCase {
     checksum: u64
 }
 
-    /// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
+/// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
 /// Marvin32 implementation. This implementation, per Niels Ferguson is not considered
 /// completely compliant/correct and so it should not be used. But the simple test
 /// cases here do result in matching output.
@@ -128,11 +130,15 @@ fn marvin_various_cases()
 
         // Act
         let marvin64 = microsoft_security_utilities_core::marvin::compute_hash(input, seed, 0, input.len() as i32);
+        let marvin64_slice = microsoft_security_utilities_core::marvin::compute_hash_slice(input, seed);
         let marvin32: i32 = microsoft_security_utilities_core::marvin::compute_hash32(input, seed, 0, input.len() as i32);
+        let marvin32_slice = microsoft_security_utilities_core::marvin::compute_hash32_slice(input, seed);
 
         // Assert
         assert_eq!(expected64, marvin64);
+        assert_eq!(marvin64, marvin64_slice);
         assert_eq!(expected32, marvin32);
+        assert_eq!(marvin32, marvin32_slice);
     }
 }
 

--- a/src/security_utilities_rust/src/marvin_tests.rs
+++ b/src/security_utilities_rust/src/marvin_tests.rs
@@ -7,6 +7,9 @@
 #![allow(unused_assignments)]
 
 use super::*;
+use microsoft_security_utilities_core::marvin::{
+    compute_hash, compute_hash32, compute_hash32_slice, compute_hash_slice,
+};
 
 /// Compare a Marvin checksum against a well-known test case from the native code.
 #[test]
@@ -44,18 +47,58 @@ fn marvin_longer_string()
     let expected: i64 = 0xa128eb7e7260aca2;
 
     // Act
-    let marvin: i64 = microsoft_security_utilities_core::marvin::compute_hash(&input, seed, 0, input.len() as i32);
-    let marvin_slice = microsoft_security_utilities_core::marvin::compute_hash_slice(&input, seed);
+    let marvin = compute_hash(&input, seed, 0, input.len() as i32);
+    let marvin_slice = compute_hash_slice(&input, seed);
 
     // Assert
+    assert_eq!(marvin, marvin_slice);
     assert_eq!(expected, marvin);
     assert_eq!(marvin, marvin_slice);
 }
 
+#[derive(Clone)]
 struct TestCase {
     seed: u64,
     text: Vec<u8>,
-    checksum: u64
+    length: usize,
+    checksum: u64,
+    offset: i32,
+}
+
+impl TestCase {
+    pub fn new<T>(seed: u64, checksum: u64, text: T) -> Self
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        let text: Vec<_> = text.into_iter().collect();
+        let length = text.len();
+
+        Self {
+            seed,
+            checksum,
+            offset: 0,
+            text,
+            length,
+        }
+    }
+
+    pub fn add_offset(&self, offset: i32) -> Self {
+        let mut text = vec![0u8; offset as usize];
+        text.extend_from_slice(&self.text);
+
+        Self {
+            seed: self.seed,
+            checksum: self.checksum,
+            text,
+            offset,
+            length: self.length,
+        }
+    }
+
+    pub fn add_byte_at_end(mut self) -> Self {
+        self.text.push(0);
+        self
+    }
 }
 
 /// In the spirit of cross-checking, these tests are pulled from a non-Microsoft
@@ -63,10 +106,8 @@ struct TestCase {
 /// completely compliant/correct and so it should not be used. But the simple test
 /// cases here do result in matching output.
 /// https://github.com/skeeto/marvin32/blob/21020faea884799879492204af70414facfd27e9/marvin32.c#L112
-fn create_test_cases() -> Vec<TestCase>
+fn create_test_cases() -> impl Iterator<Item = TestCase>
 {
-    let mut v: Vec<TestCase> = Vec::new();
-
     // A random seed value used by the tests referenced below.
     let seed_0: u64 = 0x004fb61a001bdbcc;
 
@@ -76,43 +117,47 @@ fn create_test_cases() -> Vec<TestCase>
     // A random seed value used by the tests referenced below.
     let seed_2: u64 = 0x804fb61a801bdbcc;
 
-    // seed_0 testcases
-    v.push(TestCase { seed: seed_0, text: "".as_bytes().to_vec(),  checksum: 0x30ed35c100cd3c7d});
-    v.push(TestCase { seed: seed_0, text: [175].to_vec(), checksum: 0x48e73fc77d75ddc1});
-    v.push(TestCase { seed : seed_0, text : [231, 15].to_vec(),  checksum : 0xb5f6e1fc485dbff8});
-    v.push(TestCase { seed : seed_0, text : [55, 244, 149].to_vec(),  checksum : 0xf0b07c789b8cf7e8});
-    v.push(TestCase { seed : seed_0, text : [134, 66, 220, 89].to_vec(),  checksum : 0x7008f2e87e9cf556});
-    v.push(TestCase { seed : seed_0, text : [21, 63, 183, 152, 38].to_vec(),  checksum : 0xe6c08c6da2afa997});
-    v.push(TestCase { seed : seed_0, text : [9, 50, 230, 36, 108, 71].to_vec(),  checksum :0x6f04bf1a5ea24060});
-    v.push(TestCase { seed : seed_0, text : [171, 66, 126, 168, 209, 15, 199].to_vec(),  checksum : 0xe11847e4f0678c41});
+    #[rustfmt::skip]
+    let v = vec![
+        // seed_0 test cases
+        TestCase::new(seed_0, 0x30ed35c100cd3c7d, []),
+        TestCase::new(seed_0, 0x48e73fc77d75ddc1, [175]),
+        TestCase::new(seed_0, 0xb5f6e1fc485dbff8, [231, 15]),
+        TestCase::new(seed_0, 0xf0b07c789b8cf7e8, [55, 244, 149]),
+        TestCase::new(seed_0, 0x7008f2e87e9cf556, [134, 66, 220, 89]),
+        TestCase::new(seed_0, 0xe6c08c6da2afa997, [21, 63, 183, 152, 38]),
+        TestCase::new(seed_0, 0x6f04bf1a5ea24060, [9, 50, 230, 36, 108, 71]),
+        TestCase::new(seed_0, 0xe11847e4f0678c41, [171, 66, 126, 168, 209, 15, 199]),
 
-    // seed_1 testcases
-    v.push(TestCase { seed : seed_1, text : "".as_bytes().to_vec(),  checksum : 0x10a9d5d3996fd65d});
-    v.push(TestCase { seed : seed_1, text : [175].to_vec(), checksum : 0x68201f91960ebf91});
-    v.push(TestCase { seed : seed_1, text : [231, 15].to_vec(),  checksum : 0x64b581631f6ab378});
-    v.push(TestCase { seed : seed_1, text : [55, 244, 149].to_vec(),  checksum : 0xe1f2dfa6e5131408});
-    v.push(TestCase { seed : seed_1, text : [134, 66, 220, 89].to_vec(),  checksum : 0x36289d9654fb49f6});
-    v.push(TestCase { seed : seed_1, text : [21, 63, 183, 152, 38].to_vec(),  checksum : 0x0a06114b13464dbd});
-    v.push(TestCase { seed : seed_1, text : [9, 50, 230, 36, 108, 71].to_vec(),  checksum : 0xd6dd5e40ad1bc2ed});
-    v.push(TestCase { seed : seed_1, text : [171, 66, 126, 168, 209, 15, 199].to_vec(),  checksum : 0xe203987dba252fb3});
+        TestCase::new(seed_1, 0x10a9d5d3996fd65d, []),
+        TestCase::new(seed_1, 0x68201f91960ebf91, [175]),
+        TestCase::new(seed_1, 0x64b581631f6ab378, [231, 15]),
+        TestCase::new(seed_1, 0xe1f2dfa6e5131408, [55, 244, 149]),
+        TestCase::new(seed_1, 0x36289d9654fb49f6, [134, 66, 220, 89]),
+        TestCase::new(seed_1, 0x0a06114b13464dbd, [21, 63, 183, 152, 38]),
+        TestCase::new(seed_1, 0xd6dd5e40ad1bc2ed, [9, 50, 230, 36, 108, 71]),
+        TestCase::new(seed_1, 0xe203987dba252fb3, [171, 66, 126, 168, 209, 15, 199]),
 
-    // seed_2 testcases
-    v.push( TestCase { seed : seed_2, text : [0].to_vec(),  checksum : 0xa37fb0da2ecae06c});
-    v.push( TestCase { seed : seed_2, text : [255].to_vec(),  checksum : 0xfecef370701ae054});
-    v.push( TestCase { seed : seed_2, text : [0, 255].to_vec(),  checksum : 0xa638e75700048880});
-    v.push( TestCase { seed : seed_2, text : [255, 0].to_vec(),  checksum : 0xbdfb46d969730e2a});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255].to_vec(),  checksum : 0x9d8577c0fe0d30bf});
-    v.push( TestCase { seed : seed_2, text : [0,255, 0].to_vec(),  checksum : 0x4f9fbdde15099497});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255].to_vec(),  checksum : 0x24eaa279d9a529ca});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0].to_vec(),  checksum : 0xd3bec7726b057943});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255].to_vec(),  checksum : 0x920b62bbca3e0b72});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0].to_vec(),  checksum : 0x1d7ddf9dfdf3c1bf});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0, 255].to_vec(),  checksum : 0xec21276a17e821a5});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255, 0].to_vec(),  checksum : 0x6911a53ca8c12254});
-    v.push( TestCase { seed : seed_2, text : [255, 0, 255, 0, 255, 0, 255].to_vec(),  checksum : 0xfdfd187b1d3ce784});
-    v.push( TestCase { seed : seed_2, text : [0, 255, 0, 255, 0, 255, 0].to_vec(),  checksum : 0x71876f2efb1b0ee8});
+        TestCase::new(seed_2, 0xa37fb0da2ecae06c, [0]),
+        TestCase::new(seed_2, 0xfecef370701ae054, [255]),
+        TestCase::new(seed_2, 0xa638e75700048880, [0, 255]),
+        TestCase::new(seed_2, 0xbdfb46d969730e2a, [255, 0]),
+        TestCase::new(seed_2, 0x9d8577c0fe0d30bf, [255, 0, 255]),
+        TestCase::new(seed_2, 0x4f9fbdde15099497, [0,255, 0]),
+        TestCase::new(seed_2, 0x24eaa279d9a529ca, [0, 255, 0, 255]),
+        TestCase::new(seed_2, 0xd3bec7726b057943, [255, 0, 255, 0]),
+        TestCase::new(seed_2, 0x920b62bbca3e0b72, [255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x1d7ddf9dfdf3c1bf, [0, 255, 0, 255, 0]),
+        TestCase::new(seed_2, 0xec21276a17e821a5, [0, 255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x6911a53ca8c12254, [255, 0, 255, 0, 255, 0]),
+        TestCase::new(seed_2, 0xfdfd187b1d3ce784, [255, 0, 255, 0, 255, 0, 255]),
+        TestCase::new(seed_2, 0x71876f2efb1b0ee8, [0, 255, 0, 255, 0, 255, 0]),
+    ];
 
-    return v;
+    // Generate offsets
+    v
+        .into_iter()
+        .flat_map(|v| [0, 1, 5, 100].map(|o| v.add_offset(o).add_byte_at_end()))
 }
 
 #[test]
@@ -127,15 +172,19 @@ fn marvin_various_cases()
         let seed = testcase.seed;
         let expected64: i64 = testcase.checksum as i64;
         let expected32: i32 = (expected64 ^ expected64 >> 32) as i32;
+        let offset = testcase.offset;
+        let offset_usize = offset as usize;
 
         // Act
-        let marvin64 = microsoft_security_utilities_core::marvin::compute_hash(input, seed, 0, input.len() as i32);
-        let marvin64_slice = microsoft_security_utilities_core::marvin::compute_hash_slice(input, seed);
-        let marvin32: i32 = microsoft_security_utilities_core::marvin::compute_hash32(input, seed, 0, input.len() as i32);
-        let marvin32_slice = microsoft_security_utilities_core::marvin::compute_hash32_slice(input, seed);
+        let marvin64 = compute_hash(input, seed, offset, testcase.length as i32);
+        let marvin32: i32 = compute_hash32(input, seed, offset, testcase.length as i32);
+
+        let marvin64_slice = compute_hash_slice(&input[offset_usize..(offset_usize + testcase.length)], seed);
+        let marvin32_slice =
+            compute_hash32_slice(&input[offset_usize..(offset_usize + testcase.length)], seed);
 
         // Assert
-        assert_eq!(expected64, marvin64);
+        assert_eq!(marvin64, marvin64_slice);
         assert_eq!(marvin64, marvin64_slice);
         assert_eq!(expected32, marvin32);
         assert_eq!(marvin32, marvin32_slice);
@@ -147,7 +196,7 @@ fn marvin_various_cases()
 fn marvin_compute_hash_panic_if_invalid_args_1()
 {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, -1, 0);
+    compute_hash(input, 0, -1, 0);
 }
 
 #[test]
@@ -155,7 +204,7 @@ fn marvin_compute_hash_panic_if_invalid_args_1()
 fn marvin_compute_hash_panic_if_invalid_args_2()
 {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 5, 0);
+    compute_hash(input, 0, 5, 0);
 }
 
 #[test]
@@ -163,7 +212,7 @@ fn marvin_compute_hash_panic_if_invalid_args_2()
 fn marvin_compute_hash_panic_if_invalid_args_3()
 {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 1, -1);
+    compute_hash(input, 0, 1, -1);
 }
 
 #[test]
@@ -171,5 +220,5 @@ fn marvin_compute_hash_panic_if_invalid_args_3()
 fn marvin_compute_hash_panic_if_invalid_args_4()
 {
     let input = "".as_bytes();
-    microsoft_security_utilities_core::marvin::compute_hash(input, 0, 3, 3);
+    compute_hash(input, 0, 3, 3);
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/marvin.rs
@@ -2,23 +2,24 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /// This is a Rust implementation of the Marvin32 checksum algorithm, the definitive native code for which is
-/// at https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c. 
-use std::mem;
+/// at https://github.com/microsoft/SymCrypt/blob/master/lib/marvin32.c.
 
 /// Convenience method to compute a Marvin hash and collapse it into a 32-bit hash.
-pub fn compute_hash32(data: &[u8], seed: u64, offset: i32, length: i32) -> i32
-{
-    let hash64: i64 = compute_hash(data, seed, offset, length);
+pub fn compute_hash32(data: &[u8], seed: u64, offset: i32, length: i32) -> i32 {
+    let hash64 = compute_hash(data, seed, offset, length);
     return ((hash64 >> 32) as i32) ^ (hash64 as i32);
 }
 
-/// Computes a 64-bit hash using the Marvin algorithm.
-pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
-{
-    // Marvin by design can produce a checksum for empty input buffers, which
-    // is why it's ok for the offset to point just past the end of the buffer
-    // or for the input buffer to be empty;
-    if offset < 0 || offset > data.len() as i32
+/// Convenience method to compute a Marvin hash from a slice and collapse it into a 32-bit hash.
+pub fn compute_hash32_slice(data: &[u8], seed: u64) -> i32 {
+    let hash64 = compute_hash_slice(data, seed);
+    return ((hash64 >> 32) as i32) ^ (hash64 as i32);
+}
+
+/// Computes a 64-bit hash using the Marvin algorithm from the given slice,
+/// using the provided length and offset to determine the data to hash.
+pub fn compute_hash(data: &[u8], seed: u64, offset: i32, length: i32) -> i64 {
+    if offset > data.len() as i32
     {
         panic!("Offset '{}' is out of range", offset);
     }
@@ -33,86 +34,65 @@ pub fn compute_hash(data: &[u8], seed: u64, offset: i32, mut length: i32) -> i64
         panic!("Offset ({}) + length ({}) exceeds data length ({})", offset, length, data.len());
     }
 
-    let mut p0: u32 = seed as u32;
-    let mut p1: u32 = (seed >> 32) as u32;
+    let data = &data[offset as usize..(offset + length) as usize];
+    compute_hash_slice(data, seed)
+}
 
-    let mut remaining_data_offset: i32 = 0;
+/// Computes a 64-bit hash using the Marvin algorithm from a slice.
+pub fn compute_hash_slice(data: &[u8], seed: u64) -> i64 {
+    let mut p0 = seed as u32;
+    let mut p1 = (seed >> 32) as u32;
 
-    let uint_count = length / 4;
+    let mut chunks = data.chunks_exact(4);
 
-    if length as usize >= mem::size_of::<u32>()
-    {
-        let mut index: i32 = 0 + offset;
+    for chunk in &mut chunks {
+        let u32_value = u32::from_le_bytes(chunk.try_into().expect("A slice of exactly 4 bytes"));
+        p0 = p0.wrapping_add(u32_value);
 
-        for _i in 0..uint_count
-        {
-            let d3: u32 = (data[(index + 3) as usize] as u32) << 24;
-            let d2: u32 = (data[(index + 2) as usize] as u32) << 16;
-            let d1: u32 = (data[(index + 1) as usize] as u32) << 8;
-            let d0: u32 = data[(index + 0) as usize] as u32;
-            p0 = p0.wrapping_add(d3 | d2 | d1 | d0);
-
-            block(&mut p0, &mut p1);
-            index += 4;
-        }
-
-        remaining_data_offset = length & (!3);
-        length -= remaining_data_offset;
+        let (p0_new, p1_new) = block(p0, p1);
+        p0 = p0_new;
+        p1 = p1_new;
     }
 
-    remaining_data_offset += offset;
-
-    match length
-    {
+    let remainder = chunks.remainder();
+    match remainder.len() {
         0 => p0 += 0x80,
-        1 => p0 = p0.wrapping_add(0x8000 | (data[remaining_data_offset as usize] as u32)),
+        1 => p0 = p0.wrapping_add(0x8000 | (remainder[0] as u32)),
         2 => {
-            let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
-            let d0: u32 = data[remaining_data_offset as usize] as u32;
+            let d1 = (remainder[1] as u32) << 8;
+            let d0 = remainder[0] as u32;
             p0 = p0.wrapping_add(0x800000 | d1 | d0);
         },
         3 => {
-            let d2 = (data[(remaining_data_offset as usize) + 2] as u32) << 16;
-            let d1 = (data[(remaining_data_offset as usize) + 1] as u32) << 8;
-            let d0: u32 = data[remaining_data_offset as usize] as u32;
+            let d2 = (remainder[2] as u32) << 16;
+            let d1 = (remainder[1] as u32) << 8;
+            let d0 = remainder[0] as u32;
             p0 = p0.wrapping_add(0x80000000 | d2 | d1 | d0);
-        },
-        _ => panic!("Hash computation reached an invalid state")
+        }
+        _ => unreachable!("Hash computation reached an invalid state"),
     }
 
-    block(&mut p0, &mut p1);
-    block(&mut p0, &mut p1);
+    let (p0, p1) = block(p0, p1);
+    let (p0, p1) = block(p0, p1);
 
-    return (((p1 as i64) << 32) | (p0 as i64)) as i64;
+    return ((p1 as i64) << 32) | (p0 as i64);
 }
 
-    /// Combines hash code of multiple objects while trying to minimize possibility of collisions.
-    /// rp0: hash code seed.
-    /// rp1: Delegates to generate hash codes to combine.
-fn block(rp0:&mut u32, rp1:&mut u32)
-{
-    let mut p0: u32 = *rp0;
-    let mut p1: u32 = *rp1;
-
+/// Combines hash code of multiple objects while trying to minimize possibility of collisions.
+/// rp0: hash code seed.
+/// rp1: Delegates to generate hash codes to combine.
+fn block(mut p0: u32, mut p1: u32) -> (u32, u32) {
     p1 = p1 ^ p0;
-    p0 = rotate(p0, 20);
+    p0 = p0.rotate_left(20);
 
     p0 = p0.wrapping_add(p1);
-    p1 = rotate(p1, 9);
+    p1 = p1.rotate_left(9);
 
     p1 = p1 ^ p0;
-    p0 = rotate(p0, 27);
+    p0 = p0.rotate_left(27);
 
     p0 = p0.wrapping_add(p1);
-    p1 = rotate(p1, 19);
+    p1 = p1.rotate_left(19);
 
-    *rp0 = p0;
-    *rp1 = p1;
+    (p0, p1)
 }
-
-/// Shift bits in an unsigned integer.
-fn rotate(value: u32, shift: i32) -> u32
-{
-    (value << shift) | (value >> (32 - shift))
-}
-    


### PR DESCRIPTION
Instead of re-using the offset/length arguments, we can simply construct a slice and operate on that, making the code a lot more concise and about 33% faster.

Also increased test coverage to test non-default offsets and lengths for correct output.

The first commit adds only the slice methods & equality tests, the second one modifies the tests more extensively.

[Benchmark](https://github.com/datdenkikniet/security-utilities/blob/bench/src/security_utilities_rust/benches/marvin.rs)