### PR TITLE
Rust/His: Introduce ScanEngine struct

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -13,6 +13,7 @@
 
 # UNRELEASED
 - DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
+- BRK: `Scan` struct now comprises a `ScanEngine` and a `ScanState` instance. Scan information, such as `checks`, must be accessed via the `ScanState` field of the `Scan` struct. 
 
 # 1.5.2 - 07/05/2024
 - NEW: Added an initial secret redaction capability to the Rust package.


### PR DESCRIPTION
Previously the Scan struct would track it's own state as well as allow external state operations. To do this though, it required a RefCell instance for the non-external state. This prevented the Scan struct from being fully used in scoped thread contexts without a Mutex or Arc.

Introduce the ScanEngine struct which contains all the same code as the Scan struct (rename) as before except for the internal state tracking.

Re-write the Scan struct to simply host the ScanEngine and a ScanState. This ensures the logic is the same as before, however, now we can completely drop the RefCell and make it much clearer for callers what we expect them to do.