### PR TITLE
Rust/c3id: Decrease allocations & formatting

### DIFF
--- a/src/security_utilities_rust/src/cross_company_correlating_id_tests.rs
+++ b/src/security_utilities_rust/src/cross_company_correlating_id_tests.rs
@@ -1,16 +1,53 @@
-#[cfg(test)]
+#![cfg(test)]
+
+use microsoft_security_utilities_core::cross_company_correlating_id::hex_encode;
+
 use super::*;
 
 /// Compare a Rust generated C3Id against a well-known test case from C#.
 #[test]
-fn validate_cross_company_correlation_id() {    
+fn validate_cross_company_correlation_id() {
     // Assume
     let secret = "test";
     let expected_c3id = "rPHgxCVAOw6CZsT9xXEw";
 
     // Act
     let actual_c3id: String = microsoft_security_utilities_core::cross_company_correlating_id::generate_cross_company_correlating_id(secret);
-    
+
     // Assert
     assert_eq!(expected_c3id, actual_c3id);
+}
+
+#[test]
+fn hex_valid() {
+    let res = [
+        (0, b'0'),
+        (1, b'1'),
+        (2, b'2'),
+        (3, b'3'),
+        (4, b'4'),
+        (5, b'5'),
+        (6, b'6'),
+        (7, b'7'),
+        (8, b'8'),
+        (9, b'9'),
+        (10, b'A'),
+        (11, b'B'),
+        (12, b'C'),
+        (13, b'D'),
+        (14, b'E'),
+        (15, b'F'),
+    ];
+
+    for (input, output) in res {
+        let hex = hex_encode(input).unwrap();
+        assert_eq!(hex, output, "{}, {}, {}", input, output, hex as char);
+    }
+}
+
+#[test]
+fn hex_invalid() {
+    for v in 16..u8::MAX {
+        assert!(hex_encode(v).is_none());
+    }
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -27,8 +27,9 @@ pub fn generate_cross_company_correlating_id(text: &str) -> String {
 
 fn generate_sha256_hash<'a>(text: &str, buffer: &'a mut [u8; 64]) -> &'a [u8; 64] {
     let result = THREAD_LOCAL_SHA256.with(|sha| {
-        sha.borrow_mut().update(text.as_bytes());
-        sha.borrow_mut().finalize_reset()
+        let mut sha = sha.borrow_mut();
+        sha.update(text.as_bytes());
+        sha.finalize_reset()
     });
 
     let data: [u8; 32] = result.into();

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -4,14 +4,14 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
-use std::fmt::Write;
 
 thread_local! {
     static THREAD_LOCAL_SHA256: RefCell<Sha256> = RefCell::new(Sha256::new());
 }
 
 pub fn generate_cross_company_correlating_id(text: &str) -> String {
-    let hash = generate_sha256_hash(text);
+    let mut buffer = [0u8; 64];
+    let hash = generate_sha256_hash(text, &mut buffer);
 
     let checksum = THREAD_LOCAL_SHA256.with(|sha| {
         let mut sha = sha.borrow_mut();
@@ -25,13 +25,32 @@ pub fn generate_cross_company_correlating_id(text: &str) -> String {
     STANDARD.encode(to_encode)
 }
 
-fn generate_sha256_hash(text: &str) -> String {
+fn generate_sha256_hash<'a>(text: &str, buffer: &'a mut [u8; 64]) -> &'a [u8; 64] {
     let result = THREAD_LOCAL_SHA256.with(|sha| {
         sha.borrow_mut().update(text.as_bytes());
         sha.borrow_mut().finalize_reset()
     });
 
-    let mut output = String::with_capacity(2 * 32);
-    write!(output, "{:X}", result).unwrap();
-    output
+    let data: [u8; 32] = result.into();
+
+    for (idx, byte) in data.into_iter().enumerate() {
+        // NOTE(unwrap): u8 & 0xF is always valid.
+        let lhs = hex_encode((byte >> 4) & 0xF).unwrap();
+        let rhs = hex_encode(byte & 0xF).unwrap();
+
+        buffer[idx * 2] = lhs;
+        buffer[(idx * 2) + 1] = rhs;
+    }
+
+    buffer
+}
+
+pub(crate) fn hex_encode(value: u8) -> Option<u8> {
+    if value < 10 {
+        Some(value.wrapping_add(b'0'))
+    } else if value < 16 {
+        Some(value.wrapping_sub(10).wrapping_add(b'A'))
+    } else {
+        None
+    }
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use sha2::{Sha256, Digest};
-use std::fmt;
+use sha2::{Digest, Sha256};
 use std::cell::RefCell;
+use std::fmt::Write;
 
 thread_local! {
     static THREAD_LOCAL_SHA256: RefCell<Sha256> = RefCell::new(Sha256::new());
@@ -13,23 +13,25 @@ thread_local! {
 pub fn generate_cross_company_correlating_id(text: &str) -> String {
     let hash = generate_sha256_hash(text);
 
-    let hash = format!("CrossMicrosoftCorrelatingId:{}", hash);
-
     let checksum = THREAD_LOCAL_SHA256.with(|sha| {
-        sha.borrow_mut().update(hash.as_bytes());
-        sha.borrow_mut().finalize_reset()
+        let mut sha = sha.borrow_mut();
+
+        sha.update("CrossMicrosoftCorrelatingId:");
+        sha.update(hash);
+        sha.finalize_reset()
     });
 
     let to_encode = &checksum[0..15];
     STANDARD.encode(to_encode)
 }
 
-pub fn generate_sha256_hash(text: &str) -> String {
-
+fn generate_sha256_hash(text: &str) -> String {
     let result = THREAD_LOCAL_SHA256.with(|sha| {
         sha.borrow_mut().update(text.as_bytes());
         sha.borrow_mut().finalize_reset()
     });
 
-    fmt::format(format_args!("{:X}", result))
+    let mut output = String::with_capacity(2 * 32);
+    write!(output, "{:X}", result).unwrap();
+    output
 }

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/cross_company_correlating_id.rs
@@ -32,8 +32,12 @@ fn generate_sha256_hash<'a>(text: &str, buffer: &'a mut [u8; 64]) -> &'a [u8; 64
         sha.finalize_reset()
     });
 
+
     let data: [u8; 32] = result.into();
 
+    // ASCII-Hex encode the data.
+    // This is equivalent to write!(some_str, "{:X}", &data[..]);
+    // but avoids the need for a heap-allocated string buffer.
     for (idx, byte) in data.into_iter().enumerate() {
         // NOTE(unwrap): u8 & 0xF is always valid.
         let lhs = hex_encode((byte >> 4) & 0xF).unwrap();


### PR DESCRIPTION
Reducing the amount of required allocations improves performance by about 27% for few-block computations (0 to 88 characters), and by about 7% for many block (1024 characters) due to reduced (re-)allocation overhead.

[Benchmark](https://github.com/microsoft/security-utilities/blob/users/jdraaijer/bench/src/security_utilities_rust/benches/cross_company_correlating_id.rs)