### PR TITLE
Adding release notes for Rust crates

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,10 +11,6 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
-- DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
-- BRK: `Scan` struct now comprises a `ScanEngine` and a `ScanState` instance. Scan information, such as `checks`, must be accessed via the `ScanState` field of the `Scan` struct. 
-
 # 1.5.2 - 07/05/2024
 - NEW: Added an initial secret redaction capability to the Rust package.
 

--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -1,5 +1,5 @@
 # Release Notes
-This document contains release notes pertaining to the Rust cargo packages.
+This document contains release notes pertaining to the Rust crates.
 
 ## Definitions
 

--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -1,0 +1,27 @@
+# Release Notes
+This document contains release notes pertaining to the Rust cargo packages.
+
+## Definitions
+
+- RUL => New detection.
+- DEP => Update dependency.
+- BRK => General breaking change.
+- BUG => General bug fix.
+- NEW => New API or feature.
+- PRF => Performance work.
+- FPS => False positive reduction in static analysis.
+- FNS => False negative reduction in static analysis.
+
+# UNRELEASED
+- DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
+- BRK: `Scan` struct now comprises a `ScanEngine` and a `ScanState` instance. Scan information, such as `checks`, must be accessed via the `ScanState` field of the `Scan` struct. 
+
+# 1.5.2 - 07/05/2024
+- NEW: Added an initial secret redaction capability to the Rust package.
+
+# 1.5.1 - 06/27/2024
+- DEP: Rust packages now depend on `msvc_spectre_libs` to link Spectre-mitigated libraries for `msvc` targets.
+- NEW: Rust packages now support common annotated security key generation and validation, with semantics equivalent to C# version.
+
+# 1.4.24 - 06/03/2024
+- BUG: Make `microsoft_security_utilities_core` Rust module public. The module cannot be consumed otherwise.

--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -14,7 +14,7 @@ This document contains release notes pertaining to the Rust crates.
 
 # UNRELEASED
 - DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
-- NEW: Introduces the `ScanEngine` struct, which now encapsulates the internal state tracking previously managed by the `Scan` struct. This refactor simplifies the usage of the `Scan` struct in scoped thread contexts, removing the requirement for a `Mutex` or `Arc`.
+- NEW: Introduces the `ScanEngine` struct, which allows simplified usage in concurrent scenarios---a single `ScanEngine` instance, along with per-thread `ScanState` instances, suffice without the need for additional synchronization. The existing `Scan` struct is operationally unchanged for users.
 
 # 1.5.2 - 07/05/2024
 - NEW: Added an initial secret redaction capability to the Rust package.

--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -14,7 +14,7 @@ This document contains release notes pertaining to the Rust crates.
 
 # UNRELEASED
 - DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
-- BRK: `Scan` struct now comprises a `ScanEngine` and a `ScanState` instance. Scan information, such as `checks`, must be accessed via the `ScanState` field of the `Scan` struct. 
+- NEW: Introduces the `ScanEngine` struct, which now encapsulates the internal state tracking previously managed by the `Scan` struct. This refactor simplifies the usage of the `Scan` struct in scoped thread contexts, removing the requirement for a `Mutex` or `Arc`.
 
 # 1.5.2 - 07/05/2024
 - NEW: Added an initial secret redaction capability to the Rust package.


### PR DESCRIPTION
This PR creates a new release notes document for the Rust crates. This cleanly partitions updates to C# and Rust packages. The PR also moves over some entries from the existing Release Notes. 