### PR TITLE
Updating Rust crate versions

### DIFF
--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -12,7 +12,7 @@ This document contains release notes pertaining to the Rust crates.
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
+# 1.5.3 - 07/26/2024
 - DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
 - NEW: Introduces the `ScanEngine` struct, which allows simplified usage in concurrent scenarios---a single `ScanEngine` instance, along with per-thread `ScanState` instances, suffice without the need for additional synchronization. The existing `Scan` struct is operationally unchanged for users.
 - BRK: `Send` and `Sync` bounds have been added for `ScanDefinition` validators. This allows `ScanEngine` to be `Send + Sync`.

--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/security_utilities_rust_ffi/Cargo.toml
+++ b/src/security_utilities_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft_security_utilities_core_ffi"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
This PR prepares for a release of Rust crate v1.5.3 of security-utilities-core.