### PR TITLE
Rust/His: Add missing scan_defs() method on Scan

### DIFF
--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -1128,6 +1128,8 @@ impl Scan {
 
     pub fn possible_matches(&self) -> &Vec<PossibleScanMatch> { self.state.possible_matches() }
 
+    pub fn scan_defs(&self) -> &Vec<ScanDefinition> { &self.engine.options.defs }
+
     pub fn reset(&mut self) {
         self.state.reset();
     }


### PR DESCRIPTION
When the Scan struct was updated to use a ScanEngine, the scan_defs() method was missed being added. This caused the FFI crate to break unknowingly.

Add scan_defs() to the Scan struct, so it behaviors exactly as before.