### PR TITLE
Generate annotated hash

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,8 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# [1.6.0](https://www.nuget.org/packages/Microsoft.Security.Utilities.Core/1.6.0) - 08/06/2024
+UNRELEASED 
+- NEW: Add `ComputeCommonAnnotatedHash` to generate annotated fingerprints from arbitrary strings.
 - NEW: Provide `StandardCommonAnnotatedKeySizeInBytes` and `LongFormCommonAnnotatedKeySizeInBytes` constants (63 and 64, respectively).
 - NEW: `TryValidateCommonAnnotatedKey(byte[], string)` to facilitate working with keys as byte arrays.
 - NEW: `ComputeDerivedCommonAnnotatedKey(string, byte[])` to facilitate working with keys as byte arrays.

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -166,11 +166,12 @@ public static class IdentifiableSecrets
         return result;
     }
 
-    public static string ComputeDerivedCommonAnnotatedKey(string derivationInput,
+    public static byte[] ComputeDerivedCommonAnnotatedKey(string derivationInput,
                                                           byte[] commonAnnotatedSecret)
     {
-        string keyText = Convert.ToBase64String(commonAnnotatedSecret);
-        return ComputeDerivedCommonAnnotatedKey(derivationInput, keyText);
+        string keyText = Encoding.UTF8.GetString(commonAnnotatedSecret);
+        string derivedKey = ComputeDerivedCommonAnnotatedKey(derivationInput, keyText);
+        return Convert.FromBase64String(derivedKey);
     }
 
     public static string ComputeDerivedCommonAnnotatedKey(string derivationInput,
@@ -182,7 +183,7 @@ public static class IdentifiableSecrets
     public static byte[] ComputeCommonAnnotatedHash(string textToHash,
                                                     byte[] commonAnnotatedSecret)
     {
-        string keyText = Convert.ToBase64String(commonAnnotatedSecret);
+        string keyText = Encoding.UTF8.GetString(commonAnnotatedSecret);
         string hash = ComputeCommonAnnotatedHash(textToHash, keyText, 'H');
         return Convert.FromBase64String(hash);
     }

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -179,12 +179,12 @@ public static class IdentifiableSecrets
         return ComputeCommonAnnotatedHash(derivationInput, commonAnnotatedSecret, 'D');
     }
 
-    public static string ComputeCommonAnnotatedHash(string textToHash,
-                                                    byte[] commonAnnotatedSecret,
-                                                    char hashedDataSignature = 'H')
+    public static byte[] ComputeCommonAnnotatedHash(string textToHash,
+                                                    byte[] commonAnnotatedSecret)
     {
         string keyText = Convert.ToBase64String(commonAnnotatedSecret);
-        return ComputeCommonAnnotatedHash(textToHash, keyText, hashedDataSignature);
+        string hash = ComputeCommonAnnotatedHash(textToHash, keyText, 'H');
+        return Convert.FromBase64String(hash);
     }
 
     public static string ComputeCommonAnnotatedHash(string textToHash,

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -166,23 +166,43 @@ public static class IdentifiableSecrets
         return result;
     }
 
-    public static string ComputeDerivedCommonAnnotatedKey(string textToHash,
+    public static string ComputeDerivedCommonAnnotatedKey(string derivationInput,
                                                           byte[] commonAnnotatedSecret)
     {
         string keyText = Convert.ToBase64String(commonAnnotatedSecret);
-        return ComputeDerivedCommonAnnotatedKey(textToHash, keyText);
+        return ComputeDerivedCommonAnnotatedKey(derivationInput, keyText);
     }
 
     public static string ComputeDerivedCommonAnnotatedKey(string derivationInput,
                                                           string commonAnnotatedSecret)
     {
+        return ComputeCommonAnnotatedHash(derivationInput, commonAnnotatedSecret, 'D');
+    }
+
+    public static string ComputeCommonAnnotatedHash(string textToHash,
+                                                    byte[] commonAnnotatedSecret,
+                                                    char hashedDataSignature = 'H')
+    {
+        string keyText = Convert.ToBase64String(commonAnnotatedSecret);
+        return ComputeCommonAnnotatedHash(textToHash, keyText, hashedDataSignature);
+    }
+
+    public static string ComputeCommonAnnotatedHash(string textToHash,
+                                                    string commonAnnotatedSecret,
+                                                    char hashedDataSignature = 'H')
+    {
+        if (hashedDataSignature != 'D' && hashedDataSignature != 'H')
+        {
+            throw new ArgumentException("The hashed data signature must be either 'D' (for derived keys) or 'H' (for arbitrary hashes).");
+        }
+
         if (!CommonAnnotatedKey.TryCreate(commonAnnotatedSecret, out CommonAnnotatedKey cask))
-        { 
+        {
             throw new ArgumentException("The provided key is not a valid common annotated security key.");
         }
 
         using var hmac = new HMACSHA512(Encoding.UTF8.GetBytes(commonAnnotatedSecret));
-        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(derivationInput));
+        byte[] hashBytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(textToHash));
 
         byte[] derivedKeyBytes = new byte[40];
         Array.Copy(hashBytes, derivedKeyBytes, derivedKeyBytes.Length);
@@ -197,7 +217,7 @@ public static class IdentifiableSecrets
 
         int checksum = Marvin.ComputeHash32(derivedKeyBytes, VersionTwoChecksumSeed, 0, derivedKeyBytes.Length);
 
-        return $"{derivedKey}{checksum.ToBase62().Substring(0,4)}";
+        return $"{derivedKey}{checksum.ToBase62().Substring(0, 4)}";
     }
 
     public static byte[] GenerateCommonAnnotatedKeyBytes(string base64EncodedSignature,

--- a/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
+++ b/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../ReleaseHistory.md" Pack="true" PackagePath="ReleaseHistory.md">
+    <None Include="../../docs/ReleaseHistory.md" Pack="true" PackagePath="ReleaseHistory.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
- NEW: Add `ComputeCommonAnnotatedHash` to generate annotated fingerprints from arbitrary strings.
