### PR TITLE
test: fix panic in generate_and_detect_common_annotated_key_test

### DIFF
--- a/src/security_utilities_rust/src/end_to_end_tests.rs
+++ b/src/security_utilities_rust/src/end_to_end_tests.rs
@@ -6,17 +6,27 @@ fn generate_and_detect_common_annotated_key_test() {
     let options = microsoft_security_utilities_core::identifiable_scans::ScanOptions::default();
     let mut scan = microsoft_security_utilities_core::identifiable_scans::Scan::new(options);
 
-    let input = microsoft_security_utilities_core::identifiable_secrets::generate_common_annotated_test_key(
-                                                    microsoft_security_utilities_core::identifiable_secrets::VERSION_TWO_CHECKSUM_SEED.clone(),
-                                                    "TEST",
-                                                    true,
-                                                    None,
-                                                    None,
-                                                    false,
-                                                    Some('a')
-                                                    );
+    // Depending on the current date, some choices of test_char will never
+    // generate a valid key, so iterate over different options to avoid.
+    let mut input = String::new();
+    for test_char in 'a'..='z' {
+        let candidate = microsoft_security_utilities_core::identifiable_secrets::generate_common_annotated_test_key(
+            microsoft_security_utilities_core::identifiable_secrets::VERSION_TWO_CHECKSUM_SEED.clone(),
+            "TEST",
+            true,
+            None,
+            None,
+            false,
+            Some(test_char)
+            );
 
-    let generated_input = input.clone().unwrap();
+        input = candidate.unwrap();
+        if !input.is_empty() {
+            break;
+        }
+    }
+
+    let generated_input = input.clone();
     let input_as_bytes = generated_input.as_bytes();
     scan.parse_bytes(input_as_bytes);
 
@@ -96,4 +106,3 @@ fn identifiable_scanning_and_validation_perf_benchmark() {
     println!("Mean time for identifiable_scan: {:?}", mean_identifiable_scan_duration);
     println!("Mean time for checksum validation: {:?}", mean_validation_duration);
 }
-


### PR DESCRIPTION
Starting on the 1st of September, `generate_and_detect_common_annotated_key_test` began failing with:

```
---- end_to_end_tests::generate_and_detect_common_annotated_key_test stdout ----
thread 'end_to_end_tests::generate_and_detect_common_annotated_key_test' panicked at src\end_to_end_tests.rs:23:49:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

`generate_common_annotated_test_key` was producing `Ok("")` since the hard-coded `test_char` combined with this month happened to generate an invalid key.

The code was hitting the second branch of `generate_common_annotated_test_key`:

``` rust
        // The HIS v2 standard requires that there be no special characters in the generated key.
        if !key.contains('+') && !key.contains('/') {
            if !long_form {
                key = key.substring(0, key.len() - 4).to_string();
            }
            return Ok(key);
        } else if test_char.is_some() {
            // We could not produce a valid test key given the current signature,
            // checksum seed, reserved bits and specified test character.
            key = String::new();
            break;
        }
```

This hardens the test to prevent failing as time changes.

Follow up:

* Check in a `Cargo.lock` to ensure deterministic packages. (This is orthogonal but package non-determinism was one of the (incorrect) hypotheses for the root cause of the failure.)
* Consider accepting a timestamp into the API so that it can be made deterministic.
* Consider returning `Err("…")` instead of `Some("")`, since `""` is not a valid test key anyways.

No release note as product code was not changed.