### PR TITLE
prep for v1.6.1. release

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# 1.6.1 - 09/06/2024
+- BUG: `v1.6.0` missing the `ComputeCommonAnnotatedHash` API.
+
 # 1.6.0 - 08/09/2024
 - NEW: Add `ComputeCommonAnnotatedHash` to generate annotated fingerprints from arbitrary strings.
 - NEW: Provide `StandardCommonAnnotatedKeySizeInBytes` and `LongFormCommonAnnotatedKeySizeInBytes` constants (63 and 64, respectively).

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
BUG: `v1.6.0` missing the `ComputeCommonAnnotatedHash` API.