### PR TITLE
Api updates to unify all key creation through a common helper.

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,8 +11,17 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# 1.6.0 - 08/09/2024
+# UNRELEASED
+- BRK: Rename `StandardCommonAnnotatedKeySize` to `StandardEncodedCommonAnnotatedKeySize` and `LongFormCommonAnnotatedKeySize` to `LongFormEncodedCommonAnnotatedKeySize` to distinguish these from const values for key lengths in bytes.
+- BUG: Correct `CommonAnnotatedKeyRegexPattern` to detect keys (as denoted by `H` in the platform signature) derived from hashing data with CASK keys or arbitrary secrets.
+- BUG: Fix issue in low-level `GenerateCommonAnnotatedTestKey` helper in which key kind signature was hard-coded for `D` (derived) for both derived and hashed keys (which should be denoted by `H`).
 - NEW: Add `ComputeCommonAnnotatedHash` to generate annotated fingerprints from arbitrary strings.
+- NEW: Add `CommonAnnotatedDerivedKeySignature` and `CommonAnnotatedHashedDataSignature` to denote these generated key variations.
+- NEW: Update key generation to use Base62 for all encoded checksums (including primary keys). As a result, all test keys (in which the randomized component is a common character) will be valid (because we no longer will generate special characters in the computed checksum).
+- NEW: Add `longForm` argument to `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` to support backwards-compatible, full 64-byte encoded forms of these keys.
+- NEW: Provide `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` overloads that accept an arbitrary secret (and which allow platform and provider data to be explicitly specified).
+
+# 1.6.0 - 08/09/2024
 - NEW: Provide `StandardCommonAnnotatedKeySizeInBytes` and `LongFormCommonAnnotatedKeySizeInBytes` constants (63 and 64, respectively).
 - NEW: `TryValidateCommonAnnotatedKey(byte[], string)` to facilitate working with keys as byte arrays.
 - NEW: `ComputeDerivedCommonAnnotatedKey(string, byte[])` to facilitate working with keys as byte arrays.

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Security.Utilities
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
             string base64EncodedSignature = key.Substring(76, 4);
 
-            if (key.Length != IdentifiableSecrets.StandardCommonAnnotatedKeySize &&
-                key.Length != IdentifiableSecrets.LongFormCommonAnnotatedKeySize)
+            if (key.Length != IdentifiableSecrets.StandardEncodedCommonAnnotatedKeySize &&
+                key.Length != IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize)
             {
                 return false;
             }
 
-            bool longForm = key.Length == IdentifiableSecrets.LongFormCommonAnnotatedKeySize;
+            bool longForm = key.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize;
 
             // This code path is intended to ensure that common annotated security keys are
             // highly backwards compatible with the older identifiable keys format. This

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Security.Utilities
             secret = null;
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
             string base64EncodedSignature = key.Substring(76, 4);
-            bool isDerived = key[DerivedKeyCharacterOffset] == 'D';
 
             if (key.Length != IdentifiableSecrets.StandardCommonAnnotatedKeySize &&
                 key.Length != IdentifiableSecrets.LongFormCommonAnnotatedKeySize)
@@ -42,11 +41,15 @@ namespace Microsoft.Security.Utilities
                 int checksum = Marvin.ComputeHash32(keyBytes, checksumSeed, 0, keyBytes.Length - 4);
 
                 byte[] checksumBytes = BitConverter.GetBytes(checksum);
-                string encodedChecksum = isDerived ? checksum.ToBase62() : Convert.ToBase64String(checksumBytes);
+                string encodedChecksum = checksumBytes.ToBase62();
 
                 if (!encodedChecksum.StartsWith(partialEncodedChecksum))
                 {
-                    return false;
+                    encodedChecksum = Convert.ToBase64String(checksumBytes);
+                    if (!encodedChecksum.StartsWith(partialEncodedChecksum))
+                    {
+                        return false;
+                    }
                 }
 
                 keyBytes[keyBytes.Length - 4] = checksumBytes[0];
@@ -134,6 +137,10 @@ namespace Microsoft.Security.Utilities
         public const int ProviderFixedSignatureLength = 4;
 
         public const int ChecksumOffset = ProviderFixedSignatureOffset + ProviderFixedSignatureLength;
+
+        public bool IsCustomerManaged => ProviderFixedSignature.Equals(ProviderFixedSignature.ToUpperInvariant());
+
+        public bool IsHashedDataKey => this.base64Key[DerivedKeyCharacterOffset] == 'H';
 
         public bool IsDerivedKey => this.base64Key[DerivedKeyCharacterOffset] == 'D';
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -32,17 +32,22 @@ namespace Microsoft.Security.Utilities
                         break;
                     }
 
-                    string example;
+                    string example = null;
 
                     try
-                    { 
-                        example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(IdentifiableSecrets.VersionTwoChecksumSeed,
-                                                                                     "TEST",
-                                                                                     customerManagedKey: true,
-                                                                                     platformReserved: null,
-                                                                                     providerReserved: null,
-                                                                                     longForm,
-                                                                                     testChar);
+                    {
+                        foreach (char keyKindSignature in new[]{ '9', 'D', 'H' })
+                        {
+                            example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(randomBytes: null,
+                                                                                         IdentifiableSecrets.VersionTwoChecksumSeed,
+                                                                                         "TEST",
+                                                                                         customerManagedKey: true,
+                                                                                         platformReserved: null,
+                                                                                         providerReserved: null,
+                                                                                         longForm,
+                                                                                         testChar,
+                                                                                         keyKindSignature);
+                        }
                     }
                     catch (InvalidOperationException)
                     {


### PR DESCRIPTION
- BRK: Rename `StandardCommonAnnotatedKeySize` to `StandardEncodedCommonAnnotatedKeySize` and `LongFormCommonAnnotatedKeySize` to `LongFormEncodedCommonAnnotatedKeySize` to distinguish these from const values for key lengths in bytes.
- BUG: Correct `CommonAnnotatedKeyRegexPattern` to detect keys (as denoted by `H` in the platform signature) derived from hashing data with CASK keys or arbitrary secrets.
- BUG: Fix issue in low-level `GenerateCommonAnnotatedTestKey` helper in which key kind signature was hard-coded for `D` (derived) for both derived and hashed keys (which should be denoted by `H`).
- NEW: Add `ComputeCommonAnnotatedHash` to generate annotated fingerprints from arbitrary strings.
- NEW: Add `CommonAnnotatedDerivedKeySignature` and `CommonAnnotatedHashedDataSignature` to denote these generated key variations.
- NEW: Update key generation to use Base62 for all encoded checksums (including primary keys). As a result, all test keys (in which the randomized component is a common character) will be valid (because we no longer will generate special characters in the computed checksum).
- NEW: Add `longForm` argument to `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` to support backwards-compatible, full 64-byte encoded forms of these keys.
- NEW: Provide `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` overloads that accept an arbitrary secret (and which allow platform and provider data to be explicitly specified).

Previously, we appear to have shipped `1.6.0` without including the `ComputeCommonAnnotatedHash` API. This API as authored required a CASK secret to operate but this is clearly not sufficient: providers that update their logic for producing derived keys and hashes may need to operate against a legacy secret that drives the signing process. To add this capability, however, we need to update the API to accept all the data (i.e., the CASK reserved platform + provider data) that is possible to encoded in a key. This was not previously required because we flowed that data from the CASK signing secret. This has the added benefit of allowing users to decide whether to flow data from a primary CASK key or to override it.

While making this change, I decided to take the plunge and simply make our key generation logic use a Base62 checksum. One positive result is that every test key (by CASK specification) will generate a legal key (because these specified patterns will *never* produce a special character that's illegal in CASK). We already had to use Base62 for the derived and hashed key cases; it is not a stretch to do so for primary keys. I've left back-up logic in the API for handling the case where the checksum is expressed as decoded base64 bytes. That means this library will continue to handle any historical key minters that are producing the older checksums.

This work also revealed a couple of small bugs related to the new hashing API: we needed to update our common regex to understand the `H` reserved key kind denoting this type and I fixed an issue in the literal generation logic that was not properly encoding `D` for derived keys and `H` for hashed.