### PR TITLE
Provide explicit confidence level for missing rules.

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -318,6 +318,24 @@
     "DetectionMetadata": "Identifiable"
   },
   {
+    "Pattern": "(^|[^0-9a-z])(?<refine>oy2[a-p][0-9a-z]{15}[aq][0-9a-z]{11}[eu][bdfhjlnprtvxz357][a-p][0-9a-z]{11}[aeimquy4])([^aeimquy4]|$)",
+    "Id": "SEC101/030",
+    "Name": "NuGetApiKey",
+    "Signatures": [
+      "oy2"
+    ],
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
+  },
+  {
+    "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
+    "Id": "SEC101/110",
+    "Name": "AzureDatabricksPat",
+    "Signatures": [
+      "dapi"
+    ],
+    "DetectionMetadata": "HighEntropy, HighConfidence"
+  },
+  {
     "Signatures": [
       "AZEG"
     ],
@@ -331,5 +349,23 @@
     "Id": "SEC101/190",
     "Name": "AzureEventGridIdentifiableKey",
     "DetectionMetadata": "Identifiable"
+  },
+  {
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?<refine>npm_[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{36})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Id": "SEC101/050",
+    "Name": "NpmAuthorKey",
+    "Signatures": [
+      "npm_"
+    ],
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
+  },
+  {
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Id": "SEC101/565",
+    "Name": "SecretScanningSampleToken",
+    "Signatures": [
+      "ab85"
+    ],
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   }
 ]

--- a/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
@@ -8,5 +8,40 @@
       "ret="
     ],
     "DetectionMetadata": "LowConfidence"
+  },
+  {
+    "Pattern": "^(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{32}$",
+    "Id": "SEC000/003",
+    "Name": "Unclassified32CharacterString",
+    "Signatures": null,
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
+  },
+  {
+    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=$",
+    "Id": "SEC000/000",
+    "Name": "Unclassified32ByteBase64String",
+    "Signatures": null,
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
+  },
+  {
+    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==$",
+    "Id": "SEC000/001",
+    "Name": "Unclassified64ByteBase64String",
+    "Signatures": null,
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
+  },
+  {
+    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{34}$",
+    "Id": "SEC101/101",
+    "Name": "AadClientAppLegacyCredentials",
+    "Signatures": null,
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence"
+  },
+  {
+    "Pattern": "^[1234567890abcdef]{32}$",
+    "Id": "SEC000/002",
+    "Name": "Unclassified16ByteHexadecimalString",
+    "Signatures": null,
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   }
 ]

--- a/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
@@ -1,5 +1,12 @@
 [
   {
+    "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
+    "Id": "SEC101/105",
+    "Name": "AzureMessageLegacyCredentials",
+    "Signatures": null,
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence"
+  },
+  {
     "Pattern": "(?:^|[^0-9A-Za-z-_.])e[0-9A-Za-z-_=]{23,}\\.e[0-9A-Za-z-_=]{23,}\\.[0-9A-Za-z-_=]{24,}(?:[^0-9A-Za-z-_]|$)",
     "Id": "SEC101/528",
     "Name": "GenericJwt",
@@ -9,6 +16,16 @@
       "ewog"
     ],
     "DetectionMetadata": "HighEntropy, MediumConfidence"
+  },
+  {
+    "Pattern": "https?:\\/\\/(?:[^:@]+):(?<refine>[^:@?]+)@",
+    "Id": "SEC101/127",
+    "Name": "UrlCredentials",
+    "Signatures": [
+      "http",
+      "https"
+    ],
+    "DetectionMetadata": "MediumConfidence"
   },
   {
     "Pattern": "(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))",

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -324,7 +324,7 @@
     "Signatures": [
       "oy2"
     ],
-    "DetectionMetadata": "HighEntropy, FixedSignature"
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
     "Pattern": "(?:[^2-7a-z]|^)(?<refine>[2-7a-z]{52})(?:[^2-7a-z]|$)",
@@ -352,7 +352,7 @@
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
     "Signatures": null,
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy"
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence"
   },
   {
     "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
@@ -361,7 +361,7 @@
     "Signatures": [
       "dapi"
     ],
-    "DetectionMetadata": "HighEntropy"
+    "DetectionMetadata": "HighEntropy, HighConfidence"
   },
   {
     "Signatures": [
@@ -385,7 +385,7 @@
     "Signatures": [
       "npm_"
     ],
-    "DetectionMetadata": "HighEntropy, FixedSignature"
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
@@ -394,6 +394,6 @@
     "Signatures": [
       "ab85"
     ],
-    "DetectionMetadata": "HighEntropy, FixedSignature"
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   }
 ]

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -18,7 +18,7 @@
       "http",
       "https"
     ],
-    "DetectionMetadata": "None"
+    "DetectionMetadata": "MediumConfidence"
   },
   {
     "Pattern": "(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))",
@@ -45,34 +45,34 @@
     "Id": "SEC000/003",
     "Name": "Unclassified32CharacterString",
     "Signatures": null,
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy, Unclassified"
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
     "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=$",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
     "Signatures": null,
-    "DetectionMetadata": "HighEntropy, Unclassified"
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
     "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==$",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
     "Signatures": null,
-    "DetectionMetadata": "HighEntropy, Unclassified"
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
     "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{34}$",
     "Id": "SEC101/101",
     "Name": "AadClientAppLegacyCredentials",
     "Signatures": null,
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy"
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence"
   },
   {
     "Pattern": "^[1234567890abcdef]{32}$",
     "Id": "SEC000/002",
     "Name": "Unclassified16ByteHexadecimalString",
     "Signatures": null,
-    "DetectionMetadata": "HighEntropy, Unclassified"
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   }
 ]

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,11 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- BUG: Mark `SEC000/000.Unclassified32ByteBase64String`, `SEC000/001.Unclassified64ByteBase64String`, `SEC101/101.AadClientAppLegacyCredentials`, `SEC000/001.Unclassified64ByteBase64String` as `DetectionMetadata.LowConfidence`.
+- BUG: Mark `SEC101/109.AzureContainerRegistryLegacyKey` as `DetectionMetadata.MediumConfidence`.
+- BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
+
 # 1.7.0 - 09/10/2024
 - BRK: Rename `StandardCommonAnnotatedKeySize` to `StandardEncodedCommonAnnotatedKeySize` and `LongFormCommonAnnotatedKeySize` to `LongFormEncodedCommonAnnotatedKeySize` to distinguish these from const values for key lengths in bytes.
 - BUG: Correct `CommonAnnotatedKeyRegexPattern` to detect keys (as denoted by `H` in the platform signature) derived from hashing data with CASK keys or arbitrary secrets.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -15,6 +15,7 @@
 - BUG: Mark `SEC000/000.Unclassified32ByteBase64String`, `SEC000/001.Unclassified64ByteBase64String`, `SEC101/101.AadClientAppLegacyCredentials`, `SEC000/001.Unclassified64ByteBase64String` as `DetectionMetadata.LowConfidence`.
 - BUG: Mark `SEC101/109.AzureContainerRegistryLegacyKey` as `DetectionMetadata.MediumConfidence`.
 - BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
+- PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 
 # 1.7.0 - 09/10/2024
 - BRK: Rename `StandardCommonAnnotatedKeySize` to `StandardEncodedCommonAnnotatedKeySize` and `LongFormCommonAnnotatedKeySize` to `LongFormEncodedCommonAnnotatedKeySize` to distinguish these from const values for key lengths in bytes.

--- a/src/Microsoft.Security.Utilities.Core/DetectionMetadata.cs
+++ b/src/Microsoft.Security.Utilities.Core/DetectionMetadata.cs
@@ -18,15 +18,47 @@ public enum DetectionMetadata
 
     EmbeddedChecksum = 1 << 3,
 
+    // The confidence that this pattern comprises sensitive data is effectively 100%.
+    // The 'identifiable' techniques for constructing security keys provides accuracy 
+    // that guarantees false positives at a rate that exceeds 1 in billions.
     Identifiable = FixedSignature | EmbeddedChecksum | HighEntropy | HighConfidence,
 
     RequiresRotation = 1 << 4,
 
     Unclassified = 1 << 5,
 
+    /// <summary>
+    /// The confidence that this pattern comprises sensitive data is low. i.e., the chance
+    /// that this pattern matches some other data generator and does not comprises anything
+    /// related to a security scenario is high. A 32-byte base64-encoded string, for example,
+    /// may comprise an Azure access key in some scenarios but in the vast majority of matches
+    /// it will simply be some other encoded data that happens to be 32 bytes long.
+    /// Configuring an analysis to include `LowConfidence` patterns is appropriate for data
+    /// collection scenarios where the goal is to maximize the number of matches or for
+    /// extremely detailed reviews of findings in urgent security scenarios that warrant it.
+    /// </summary>
     LowConfidence = 1 << 6,
 
+    /// <summary>
+    /// The confidence that this pattern comprises sensitive data is medium. i.e., in most
+    /// scenarios, we expect this finding first to identify data that is directed to a
+    /// specific security purpose. The pattern may *not* be sufficiently accurate to
+    /// determine whether the data actually comprises an exploitable credential (i.e., it
+    /// includes the literally sensitive data required to satisfy auth flows). Instead, the
+    /// match may be a false positive, in that the apparent secret actually comprises an
+    /// expanded variable. Configuring an analysis to include `MediumConfidence` patterns is
+    /// appropriate in scenarios where the productivity costs of reviewing and ignoreing
+    /// false positives is offset by the security value achieved. A scan system that
+    /// identifies medium confidence findings in incremental code changes, for example, can
+    /// typically amortize the productivity costs of medium confidence findings. A system
+    /// that attempts to hard-block processes based on detecting an apparent credential
+    /// would not enable medium confidence patterns.
+    /// </summary>
     MediumConfidence = 1 << 7,
 
+    // The confidence that this pattern comprises sensitive data is very high. i.e., the
+    // productivity costs associated with reviewing and ignoring false positives is extremely
+    // low or non-existent. Note that a pattern that is marked as `DetectionMetadata.Identifiable`
+    // has accuracy that is effectively 100%. 
     HighConfidence = 1 << 8,
 }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
@@ -19,7 +19,7 @@ internal sealed class Unclassified32ByteBase64String : RegexPattern
         Name = nameof(Unclassified32ByteBase64String);
         Pattern = $@"^[{WellKnownRegexPatterns.Base64}]{{43}}=$";
         
-        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified;
+        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }
 
     public override Tuple<string, string>? GetMatchIdAndName(string match) => new Tuple<string, string>("SEC000/000", "Unclassified32ByteBase64String");

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
@@ -21,7 +21,7 @@ internal sealed class Unclassified64ByteBase64String : RegexPattern
         Name = nameof(Unclassified64ByteBase64String);
         Pattern = $@"^[{WellKnownRegexPatterns.Base64}]{{86}}==$";
 
-        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified;
+        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }
 
     public override IEnumerable<string> GenerateTruePositiveExamples()

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_002_Unclassified16ByteHexadecimalString.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_002_Unclassified16ByteHexadecimalString.cs
@@ -19,7 +19,7 @@ internal sealed class Unclassified16ByteHexadecimalString : RegexPattern
         Name = nameof(Unclassified16ByteHexadecimalString);
         Pattern = $@"^[{WellKnownRegexPatterns.Hexadecimal}]{{32}}$";
 
-        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified;
+        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }
 
     public override Tuple<string, string>? GetMatchIdAndName(string match) => new Tuple<string, string>("SEC000/001", "Unclassified64ByteBase64String");

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_003_Unclassified32CharacterString.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_003_Unclassified32CharacterString.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC000/003";
             Name = nameof(Unclassified32CharacterString);
-            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.Unclassified;
+            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
             Pattern = $"^(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{{32}}$";
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_101_AzureClientAppLegacyCredentials34.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_101_AzureClientAppLegacyCredentials34.cs
@@ -18,7 +18,7 @@ public class AadClientAppLegacyCredentials34 : RegexPattern
     {
         Id = "SEC101/101";
         Name = AadClientAppLegacyCredentials;
-        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat;
+        DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.LowConfidence;
         Pattern = $"^[{WellKnownRegexPatterns.RegexEncodedUrlUnreserved}]{{34}}$";
     }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_030_NuGetApiKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_030_NuGetApiKey.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/030";
             Name = nameof(NuGetApiKey);
-            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy| DetectionMetadata.HighConfidence;
             Pattern = "(^|[^0-9a-z])(?<refine>oy2[a-p][0-9a-z]{15}[aq][0-9a-z]{11}[eu][bdfhjlnprtvxz357][a-p][0-9a-z]{11}[aeimquy4])([^aeimquy4]|$)";
             Signatures = new HashSet<string>(new[] { "oy2" });
         }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_050_NpmAuthorKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_050_NpmAuthorKey.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/050";
             Name = nameof(NpmAuthorKey);
-            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
             Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?<refine>npm_[{WellKnownRegexPatterns.Base62}]{{36}}){WellKnownRegexPatterns.SuffixBase62}";
             Signatures = new HashSet<string>(new[] { "npm_" });
         }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/105";
             Name = nameof(AzureMessageLegacyCredentials);
-            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat;
+            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.MediumConfidence;
             Pattern = "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)";
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
@@ -11,9 +11,10 @@ namespace Microsoft.Security.Utilities
         public AzureMessageLegacyCredentials()
         {
             Id = "SEC101/105";
-            Name = nameof(AzureMessageLegacyCredentials);
+            Name = nameof(AzureMessageLegacyCredentials);         
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.MediumConfidence;
             Pattern = "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)";
+            Signatures = new HashSet<string>(new[] { ".servicebus" });
         }
 
         public override Tuple<string, string> GetMatchIdAndName(string match)

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_110.AzureDatabricksPat.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_110.AzureDatabricksPat.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/110";
             Name = nameof(AzureDatabricksPat);
-            DetectionMetadata = DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
             Pattern = $"(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{{32,34}})(?:[^0-9a-f\\-]|$)";
             Signatures = new HashSet<string>(new[] { "dapi" });
         }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/565";
             Name = nameof(SecretScanningSampleToken);
-            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy;
+            DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
             Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{{5}}){WellKnownRegexPatterns.SuffixBase62}";
             Signatures = "ab85".ToSet();
         }

--- a/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
@@ -20,8 +20,7 @@ internal sealed class UrlCredentials : RegexPattern
 
         Signatures = new HashSet<string>(new[]
         {
-            "http",
-            "https",
+            "http"
         });
     }
 

--- a/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
@@ -16,7 +16,7 @@ internal sealed class UrlCredentials : RegexPattern
 
         Pattern = @"https?:\/\/(?:[^:@]+):(?<refine>[^:@?]+)@";
 
-        DetectionMetadata = DetectionMetadata.None;
+        DetectionMetadata = DetectionMetadata.MediumConfidence;
 
         Signatures = new HashSet<string>(new[]
         {

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 using FluentAssertions;
@@ -24,6 +25,45 @@ namespace Microsoft.Security.Utilities
             "SEC101/127.UrlCredentials",
             "SEC101/109.AzureContainerRegistryLegacyKey"
         };
+
+        [TestMethod]
+        public void WellKnownRegexPatterns_EnsureAllPatternsExpressConfidence()
+        {
+            using var assertionScope = new AssertionScope();
+
+            var rulesets = new[]{
+                WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
+                WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
+            };
+
+            var missingConfidence = new List<string>();
+
+            foreach (IEnumerable<RegexPattern> ruleset in rulesets)
+            {
+                foreach (RegexPattern pattern in ruleset)
+                {
+                    foreach (string example in pattern.GenerateTruePositiveExamples())
+                    {
+                        string moniker = pattern.GetMatchMoniker(example);
+
+                        if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
+                        pattern.DetectionMetadata.HasFlag(DetectionMetadata.MediumConfidence) ||
+                        pattern.DetectionMetadata.HasFlag(DetectionMetadata.HighConfidence))
+                        {
+                            continue;
+                        }
+
+                        missingConfidence.Add(moniker);
+
+                        // We only require a single match to identify missing confidence,
+                        // which is expressed at the pattern level.
+                        break;
+                    }
+                }
+            }
+
+            missingConfidence.Should().HaveCount(0, because: $"{string.Join(", ", missingConfidence)} are missing an explicit confidence level");
+        }
 
         [TestMethod]
         public void WellKnownRegexPatterns_EnsureAllPatternsAreReferenced()


### PR DESCRIPTION
- BUG: Mark `SEC000/000.Unclassified32ByteBase64String`, `SEC000/001.Unclassified64ByteBase64String`, `SEC101/101.AadClientAppLegacyCredentials`, `SEC000/001.Unclassified64ByteBase64String` as `DetectionMetadata.LowConfidence`.
- BUG: Mark `SEC101/109.AzureContainerRegistryLegacyKey` as `DetectionMetadata.MediumConfidence`.
- BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
- PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.

I've introduced a new unit-test that forces a development invariant, that every pattern include an explicit confidence (i.e., accuracy or precision) designation, between `High`, `Medium` and `Low`. I've also updated doc comments to try to describe these categories. Maybe I should include this as well but typically:

- Low == implemented only on an ad hoc basis for deep research or review purposes.
- Medium == suitable to surface as warnings and/or bypassable findings in blocking scenarios.
- High == very low noise rates, could be candidate for hard-blocking scenarios.
- Identifiable == mathematically nearly certain to be a true positive. Suitable for hard-blocking/other prescriptive controls.

While doing this work I noticed a medium confidence pattern was missing a signature used for pre-filtering (in .NET, these values are confirmed to present in a scan target using `string.IndexOf`, a check which is empirically observed to be ~10x - 20x faster than non-back-tracking regex engines such as `RE2`. I've added a second invariant test that insists all patterns of medium confidence or higher include one or more signatures to enable the prec-check.

@nguerrera @suvamM @rwoll @shaopeng-gh @yongyan-gh @LingZhou-gh @evelyn-ys 
