### PR TITLE
Ensure that CASK secrets round-trip through base64 without changing.

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -15,6 +15,7 @@
 - BUG: Mark `SEC000/000.Unclassified32ByteBase64String`, `SEC000/001.Unclassified64ByteBase64String`, `SEC101/101.AadClientAppLegacyCredentials`, `SEC000/001.Unclassified64ByteBase64String` as `DetectionMetadata.LowConfidence`.
 - BUG: Mark `SEC101/109.AzureContainerRegistryLegacyKey` as `DetectionMetadata.MediumConfidence`.
 - BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
+- BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).
 - PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 
 # 1.7.0 - 09/10/2024

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -71,13 +71,14 @@ namespace Microsoft.Security.Utilities
             return true;
         }
 
-        private byte[] bytes;
+        public byte[] Bytes { get; }
+
         private string base64Key;
 
         private CommonAnnotatedKey(byte[] bytes)
         {
-            this.bytes = bytes;
-            this.base64Key = Convert.ToBase64String(this.bytes);
+            this.Bytes = bytes;
+            this.base64Key = Convert.ToBase64String(this.Bytes);
         }
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace Microsoft.Security.Utilities
 
         public bool IsDerivedKey => this.base64Key[DerivedKeyCharacterOffset] == 'D';
 
-        public bool IsLongFormKey => bytes.Length == 64;
+        public bool IsLongFormKey => Bytes.Length == 64;
 
         // 123456789012345678901234567890123456789012345678901234567890123456789012345678901234[5678]
         // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaJQQJ99ADccrrrrrtttttppppASIGixi1[xx==]

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -435,7 +435,7 @@ public static class IdentifiableSecrets
         byte[] checksumBytes = BitConverter.GetBytes(checksum);
         string checksumText = GetBase62EncodedChecksum(checksumBytes);
 
-        key = $"{Convert.ToBase64String(keyBytes).Substring(0, 80)}{checksumText}==";
+        key = $"{Convert.ToBase64String(keyBytes).Substring(0, 80)}{checksumText}";
 
         if (!longForm)
         {
@@ -445,10 +445,12 @@ public static class IdentifiableSecrets
         return key;
     }
 
-    private static string GetBase62EncodedChecksum(byte[] checksumBytes)
+    internal static string GetBase62EncodedChecksum(byte[] checksumBytes)
     {
         string checksumText = checksumBytes.ToBase62();
-        checksumText = $"{checksumText}{new string('0', 6 - checksumText.Length)}";
+        checksumText = $"{checksumText}{new string('0', 6 - checksumText.Length)}==";
+
+        checksumText = Convert.ToBase64String(Convert.FromBase64String(checksumText));
         return checksumText;
     }
 
@@ -714,9 +716,11 @@ public static class IdentifiableSecrets
         int encodedChecksumLength = key.Length == LongFormEncodedCommonAnnotatedKeySize ? 8 : 4;
         string encodedChecksum = key.Substring(key.Length - encodedChecksumLength).Trim('=');
 
-        checksumBytes = BitConverter.GetBytes(actualChecksum);
 
-        return encodedChecksum.StartsWith(checksumBytes.ToBase62());
+        checksumBytes = BitConverter.GetBytes(actualChecksum);
+        string computedEncodedChecksum = GetBase62EncodedChecksum(checksumBytes).Trim('=');
+
+        return computedEncodedChecksum.StartsWith(encodedChecksum);
     }
 
     /// <summary>


### PR DESCRIPTION
- BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).

When generating CASK keys, we previously would emit final characters in the apparent base64 encoded string that weren't actually legal as the final encoded character (which must be constrained to 2 bits, one of the `A`, `Q`, `g` or `w` characters.

.NET is very forgiving of this issue when decoding and re-encoding, it will simply stop processing at the appropriate byte boundary and halt. As a result, a round-tripped CASK secret might differ from the original CASK that was emitted.

Now, the round-tripping to ensure base64-validity is added to the key minting logic.

As @rwoll has pointed out, the base64 vs. base62 confusion has resulted in unfortunate complexity in emitting this standard. Before finalizing it as a public format, we should fix that. It's too late for existing adopters! Such is the tyranny of back-compat.

Still, as long as we maintain compatibility with legacy keys, we *can* design (yet another) revision.