### PR TITLE
Byte array corrections

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [

--- a/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
@@ -10,21 +10,21 @@
     "DetectionMetadata": "LowConfidence"
   },
   {
-    "Pattern": "^(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{32}$",
+    "Pattern": "(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{32}$",
     "Id": "SEC000/003",
     "Name": "Unclassified32CharacterString",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=$",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==$",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
     "Signatures": null,
@@ -38,7 +38,7 @@
     "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence"
   },
   {
-    "Pattern": "^[1234567890abcdef]{32}$",
+    "Pattern": "(^|[^1234567890abcdef])[1234567890abcdef]{32}([^1234567890abcdef]|$)",
     "Id": "SEC000/002",
     "Name": "Unclassified16ByteHexadecimalString",
     "Signatures": null,

--- a/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
@@ -3,7 +3,9 @@
     "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
-    "Signatures": null,
+    "Signatures": [
+      ".servicebus"
+    ],
     "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence"
   },
   {
@@ -22,8 +24,7 @@
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
     "Signatures": [
-      "http",
-      "https"
+      "http"
     ],
     "DetectionMetadata": "MediumConfidence"
   },

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -351,7 +351,9 @@
     "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
-    "Signatures": null,
+    "Signatures": [
+      ".servicebus"
+    ],
     "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence"
   },
   {

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -40,21 +40,21 @@
     "DetectionMetadata": "LowConfidence"
   },
   {
-    "Pattern": "^(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{32}$",
+    "Pattern": "(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{32}$",
     "Id": "SEC000/003",
     "Name": "Unclassified32CharacterString",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=$",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==$",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
     "Signatures": null,
@@ -68,7 +68,7 @@
     "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence"
   },
   {
-    "Pattern": "^[1234567890abcdef]{32}$",
+    "Pattern": "(^|[^1234567890abcdef])[1234567890abcdef]{32}([^1234567890abcdef]|$)",
     "Id": "SEC000/002",
     "Name": "Unclassified16ByteHexadecimalString",
     "Signatures": null,

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -15,8 +15,7 @@
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
     "Signatures": [
-      "http",
-      "https"
+      "http"
     ],
     "DetectionMetadata": "MediumConfidence"
   },

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -16,6 +16,8 @@
 - BUG: Mark `SEC101/109.AzureContainerRegistryLegacyKey` as `DetectionMetadata.MediumConfidence`.
 - BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
 - BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).
+- BUG: Correct `IdentifiableSecrets` `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` helpers to preserve all randomized byte input entropy by encoding and decoding this data as base64.
+- NEW: Add `CommonAnnotatedKey` `ChecksumBytes` and `ChecksumBytesIndex` convenience methods for retrieving key checksum data.
 - PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 
 # 1.7.0 - 09/10/2024

--- a/src/Microsoft.Security.Utilities.Core/Base62.cs
+++ b/src/Microsoft.Security.Utilities.Core/Base62.cs
@@ -15,6 +15,7 @@ namespace Base62
     {
         [ThreadStatic]
         private static StringBuilder s_sb;
+        
         private const string DefaultCharacterSet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
         private const string InvertedCharacterSet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -189,7 +189,7 @@ public static class IdentifiableSecrets
                                                           byte[] commonAnnotatedSecret,
                                                           bool longForm = false)
     {
-        string keyText = Encoding.UTF8.GetString(commonAnnotatedSecret);
+        string keyText = Convert.ToBase64String(commonAnnotatedSecret);
         string derivedKey = ComputeDerivedCommonAnnotatedKey(derivationInput, keyText, longForm);
         return Convert.FromBase64String(derivedKey);
     }
@@ -205,7 +205,7 @@ public static class IdentifiableSecrets
                                                     byte[] commonAnnotatedSecret,
                                                     bool longForm = false)
     {
-        string keyText = Encoding.UTF8.GetString(commonAnnotatedSecret);
+        string keyText = Convert.ToBase64String(commonAnnotatedSecret);
         string hash = ComputeCommonAnnotatedHash(textToHash, keyText, longForm, 'H');
         return Convert.FromBase64String(hash);
     }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
@@ -17,7 +17,7 @@ internal sealed class Unclassified32ByteBase64String : RegexPattern
     {
         Id = "SEC000/000";
         Name = nameof(Unclassified32ByteBase64String);
-        Pattern = $@"^[{WellKnownRegexPatterns.Base64}]{{43}}=$";
+        Pattern = $@"{WellKnownRegexPatterns.PrefixAllBase64}[{WellKnownRegexPatterns.Base64}]{{43}}=";
         
         DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
@@ -19,7 +19,7 @@ internal sealed class Unclassified64ByteBase64String : RegexPattern
     {
         Id = "SEC000/001";
         Name = nameof(Unclassified64ByteBase64String);
-        Pattern = $@"^[{WellKnownRegexPatterns.Base64}]{{86}}==$";
+        Pattern = $@"{WellKnownRegexPatterns.PrefixAllBase64}[{WellKnownRegexPatterns.Base64}]{{86}}==";
 
         DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_002_Unclassified16ByteHexadecimalString.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_002_Unclassified16ByteHexadecimalString.cs
@@ -17,7 +17,7 @@ internal sealed class Unclassified16ByteHexadecimalString : RegexPattern
     {
         Id = "SEC000/002";
         Name = nameof(Unclassified16ByteHexadecimalString);
-        Pattern = $@"^[{WellKnownRegexPatterns.Hexadecimal}]{{32}}$";
+        Pattern = $@"{WellKnownRegexPatterns.PrefixHexadecimal}[{WellKnownRegexPatterns.Hexadecimal}]{{32}}{WellKnownRegexPatterns.SuffixHexadecimal}";
 
         DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_003_Unclassified32CharacterString.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_003_Unclassified32CharacterString.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC000/003";
             Name = nameof(Unclassified32CharacterString);
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
-            Pattern = $"^(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{{32}}$";
+            Pattern = $"(?i)[a-z0-9.=\\-:[_@\\/*\\]+?]{{32}}$";
         }
 
         public override Tuple<string, string> GetMatchIdAndName(string match)

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -13,48 +13,32 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/200";
             Name = nameof(CommonAnnotatedSecurityKey);
             DetectionMetadata = DetectionMetadata.Identifiable;
-            Pattern = $"{WellKnownRegexPatterns.PrefixAllBase64}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
+            Pattern = $"{WellKnownRegexPatterns.PrefixAllBase64}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
             Signatures = "JQQJ9".ToSet();
         }
 
         public override IEnumerable<string> GenerateTruePositiveExamples()
         {
-            int attempts = 0;
-
             foreach (bool longForm in new[] { true, false })
             {
-                while (true) 
+                for (int i = 0; i < 62; i++)
                 {
-                    char testChar = (char)('a' + attempts++);
-
-                    if (testChar == '{')
-                    {
-                        break;
-                    }
+                    char testChar = CustomAlphabetEncoder.DefaultBase62Alphabet[i];
 
                     string example = null;
 
-                    try
+                    foreach (char keyKindSignature in new[] { '9', 'D', 'H' })
                     {
-                        foreach (char keyKindSignature in new[]{ '9', 'D', 'H' })
-                        {
-                            example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(randomBytes: null,
-                                                                                         IdentifiableSecrets.VersionTwoChecksumSeed,
-                                                                                         "TEST",
-                                                                                         customerManagedKey: true,
-                                                                                         platformReserved: null,
-                                                                                         providerReserved: null,
-                                                                                         longForm,
-                                                                                         testChar,
-                                                                                         keyKindSignature);
-                        }
+                        example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(randomBytes: null,
+                                                                                     IdentifiableSecrets.VersionTwoChecksumSeed,
+                                                                                     "TEST",
+                                                                                     customerManagedKey: true,
+                                                                                     platformReserved: null,
+                                                                                     providerReserved: null,
+                                                                                     longForm,
+                                                                                     testChar,
+                                                                                     keyKindSignature);
                     }
-                    catch (InvalidOperationException)
-                    {
-                        example = null;
-                    }
-
-                    if (example == null) { continue; }
 
                     yield return example;
                 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright(c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
 using FluentAssertions;
 using FluentAssertions.Execution;
 
 using Microsoft.Security.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using System;
-using System.Linq;
-
 namespace Tests.Microsoft.Security.Utilities.Core
 {
-    [TestClass]
+    [TestClass, ExcludeFromCodeCoverage]
     public class IdentifiableScanTests
     {
         [TestMethod]

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -73,6 +73,51 @@ namespace Microsoft.Security.Utilities
 
 
         [TestMethod]
+        public void IdentifiableSecrets_ComputeCommonAnnotatedHashByteArrayOverloadsShouldFunction()
+        {
+            using var assertionScope = new AssertionScope();
+
+            foreach (bool customerManagedKey in new[] { true, false })
+            {
+                foreach (bool longForm in new[] { true, false })
+                {
+                    byte[] commonAnnotatedSecret = Convert.FromBase64String(
+                        IdentifiableSecrets.GenerateCommonAnnotatedKey("TEST",
+                                                                       customerManagedKey,
+                                                                       new byte[9],
+                                                                       new byte[3],
+                                                                       longForm));
+
+                    string textToHash = "NonsensitiveData";
+
+                    byte[] keyBytes = IdentifiableSecrets.ComputeCommonAnnotatedHash(textToHash, commonAnnotatedSecret);
+                    string key = Convert.ToBase64String(keyBytes);
+
+                    bool result = CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey caKey);
+                    result.Should().BeTrue(because: "the ComputeCommonAnnotatedHash return value should be a valid cask");
+
+                    result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, "TEST");
+                    result.Should().BeTrue(because: "the ComputeCommonAnnotatedHash return value should validate using 'IdentifiableSecrets.TryValidateCommonAnnotatedKey'");
+
+                    commonAnnotatedSecret = IdentifiableSecrets.GenerateCommonAnnotatedKeyBytes("TEST",
+                                                                                                customerManagedKey,
+                                                                                                new byte[9],
+                                                                                                new byte[3],
+                                                                                                longForm);
+
+                    keyBytes = IdentifiableSecrets.ComputeCommonAnnotatedHash(textToHash, commonAnnotatedSecret);
+                    key = Convert.ToBase64String(keyBytes);
+
+                    result = CommonAnnotatedKey.TryCreate(key, out caKey);
+                    result.Should().BeTrue(because: "the ComputeCommonAnnotatedHash return value should be a valid cask");
+
+                    result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, "TEST");
+                    result.Should().BeTrue(because: "the ComputeCommonAnnotatedHash return value should validate using 'IdentifiableSecrets.TryValidateCommonAnnotatedKey'");
+                }
+            }
+        }
+
+        [TestMethod]
         public void IdentifiableSecrets_TryValidateCommonAnnotatedKey_GenerateCommonAnnotatedKey_LongForm()
         {
             using var assertionScope = new AssertionScope();

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 
-using Base62;
+// Copyright(c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,7 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Security.Utilities
 {
-    [TestClass]
+    [TestClass, ExcludeFromCodeCoverage]
     public class IdentifiableSecretsTests
     {
         private static Random s_random;
@@ -32,45 +35,228 @@ namespace Microsoft.Security.Utilities
         }
 
         private static string s_base62Alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+        [TestMethod]
+        public void IdentifiableSecrets_GenerateCommonAnnotatedTestKey()
+        {
+            string signature = GetRandomSignature();
 
+            byte[] platformReserved = new byte[9];
+            byte[] providerReserved = new byte[3];
+
+            Action action = () => IdentifiableSecrets.GenerateCommonAnnotatedTestKey(new byte[64],
+                                                                                     ulong.MaxValue,
+                                                                                     signature,
+                                                                                     customerManagedKey: true,
+                                                                                     platformReserved,
+                                                                                     providerReserved,
+                                                                                     longForm: true,
+                                                                                     'x',
+                                                                                     '9');
+
+            action.Should().NotThrow<ArgumentException>(because: $"platform and provider byte counts are correct for GenerateCommonAnnotatedTestKey");
+
+            platformReserved = new byte[8];
+            action.Should().Throw<ArgumentException>(because: $"platform byte count must be 9 for GenerateCommonAnnotatedTestKey");
+
+            platformReserved = new byte[9];
+            providerReserved = new byte[2];
+            action.Should().Throw<ArgumentException>(because: $"provider byte count must be 9 for GenerateCommonAnnotatedTestKey");
+        }
 
         [TestMethod]
-        public void IdentifiableSecrets_ComputeCommonAnnotatedHashFunctions()
+        public void IdentifiableSecrets_ComputeDerivedIdentifiableKeyThrowsOnInvalidSecret()
         {
-            int failed = 0;
-            int succeeded = 0;
-            int iterations = 1000;
+            string signature = GetRandomSignature();
 
-            for (int i = 0; i < iterations; i++)
+            foreach (bool longForm in new[] { true, false })
             {
-                foreach (bool longForm in new[] { true, false })
+                string key = Convert.ToBase64String(new byte[64]);
+                Action action = () => IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey("NonsensitiveData",
+                                                                                           key,
+                                                                                           longForm);
+
+                action.Should().Throw<ArgumentException>(because: $"'{key}' is not a valid secret for ComputeDerivedCommonAnnotatedKey");
+             
+                key = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature, customerManagedKey: true, new byte[9], new byte[3], longForm);
+
+                action.Should().NotThrow<ArgumentException>(because: $"'{key}' is a valid secret for ComputeDerivedCommonAnnotatedKey");
+
+                int index = s_random.Next() % key.Length;
+                string updatedKey = $"{key.Substring(0, index)}X{key.Substring(index + 1)}";
+
+                if (updatedKey != key)
                 {
-                    string testKey = IdentifiableSecrets.GenerateCommonAnnotatedKey("TEST",
-                                                                                    customerManagedKey: true,
-                                                                                    new byte[9],
-                                                                                    new byte[3],
-                                                                                    longForm);
+                    key = updatedKey;
+                    action.Should().Throw<ArgumentException>(because: $"'{key}' is not a valid secret for ComputeDerivedCommonAnnotatedKey");
+                }
+            }
+        }
 
-                    byte[] testBytes = Convert.FromBase64String(testKey);
-                    string roundtripped = Convert.ToBase64String(testBytes);
+        [TestMethod]
+        public void IdentifiableSecrets_ComputeCommonAnnotatedHashRequiresCorrectIdentifiers()
+        {
+            using var assertionScope = new AssertionScope();
 
-                    roundtripped.Should().Be(testKey);
+            string signature = GetRandomSignature();
 
-                    if (CommonAnnotatedKey.TryCreate(roundtripped, out CommonAnnotatedKey cask) &&
-                        IdentifiableSecrets.TryValidateCommonAnnotatedKey(roundtripped, "TEST"))
+            for (int i = 0; i < CustomAlphabetEncoder.DefaultBase64Alphabet.Length; i++)
+            {
+                foreach (bool customerManagedKey in new[] { true, false })
+                {
+                    foreach (bool longForm in new[] { true, false })
                     {
-                        succeeded++;
-                    }
-                    else
-                    {
-                        failed++; ;
+                        char keyKindSignature = CustomAlphabetEncoder.DefaultBase64Alphabet[i];
+
+                        if (keyKindSignature == 'D' || keyKindSignature == 'H')
+                        {
+                            continue;
+                        }
+
+                        Action action = () => IdentifiableSecrets.ComputeCommonAnnotatedHash("NonsensitiveData",
+                                                                                             new byte[64],
+                                                                                             signature,
+                                                                                             customerManagedKey,
+                                                                                             new byte[9],
+                                                                                             new byte[3],
+                                                                                             longForm,
+                                                                                             keyKindSignature);
+
+                        action.Should().Throw<ArgumentException>(because: $"'{keyKindSignature}' should not be a valid ComputeCommonAnnotatedHash identifier");
+
+                        action = () => IdentifiableSecrets.ComputeCommonAnnotatedHash("NonsensitiveData",
+                                                                                      Convert.ToBase64String(new byte[64]),
+                                                                                      longForm, 
+                                                                                      keyKindSignature);
+
+                        action.Should().Throw<ArgumentException>(because: $"'{keyKindSignature}' should not be a valid ComputeCommonAnnotatedHash identifier");
                     }
                 }
             }
-
-            failed.Should().Be(0);
         }
 
+        [TestMethod]
+        public void IdentifiableSecrets_TryValidateCommonAnnotatedKeyInvalidLengths()
+        {
+            using var assertionScope = new AssertionScope();
+
+            string signature = GetRandomSignature();
+
+            bool result = IdentifiableSecrets.TryValidateCommonAnnotatedKey((byte[])null, signature);
+            result.Should().BeFalse(because: "null key should not validate in 'TryValidateCommonAnnotatedKey'");
+
+            for (int i = 0; i < 100; i++)
+            {
+                if (i == IdentifiableSecrets.StandardCommonAnnotatedKeySizeInBytes ||
+                    i == IdentifiableSecrets.LongFormCommonAnnotatedKeySizeInBytes)
+                {
+                    continue;
+                }
+
+                result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(new byte[i], signature);
+                result.Should().BeFalse(because: $"byte array of invalid length '{i} should not validate in 'TryValidateCommonAnnotatedKey'");
+            }
+        }
+
+        [TestMethod]
+        public void IdentifiableSecrets_TryValidateCommonAnnotatedKeyBase64EncodedChecksums()
+        {
+            using var assertionScope = new AssertionScope();
+
+            for (int i = 0; i < 1; i++)
+            {
+                foreach (bool longForm in new[] { true, false })
+                {
+                    string signature = GetRandomSignature();
+                    string key = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature,
+                                                                                customerManagedKey: true,
+                                                                                new byte[9],
+                                                                                new byte[3],
+                                                                                longForm);
+
+                    byte[] keyBytes = Convert.FromBase64String(key);
+
+                    ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
+
+                    int firstChecksumByteIndex = CommonAnnotatedKey.ChecksumBytesIndex;
+                    byte[] bytesToChecksum = new byte[firstChecksumByteIndex];
+                    Array.Copy(keyBytes, bytesToChecksum, bytesToChecksum.Length);
+
+                    int checksum = Marvin.ComputeHash32(bytesToChecksum, checksumSeed, 0, bytesToChecksum.Length);
+                    byte[] computedChecksumBytes = BitConverter.GetBytes(checksum);
+
+                    int checksumLength = longForm ? 4 : 3;
+                    Array.Copy(computedChecksumBytes, 0, keyBytes, CommonAnnotatedKey.ChecksumBytesIndex, checksumLength);
+
+                    bool result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                    result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
+
+                    CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask);
+                    cask.Should().NotBeNull(because: $"the '{key}' should be a valid cask");
+
+                    byte[] originalChecksum = new byte[cask.ChecksumBytes.Length];
+                    Array.Copy(keyBytes, CommonAnnotatedKey.ChecksumBytesIndex, originalChecksum, 0, originalChecksum.Length);
+
+                    for (int j = 0; j < cask.ChecksumBytes.Length; j++)
+                    {
+                        // Ensure that the we've restored the key entirely
+                        Array.Copy(originalChecksum, 0, keyBytes, CommonAnnotatedKey.ChecksumBytesIndex, originalChecksum.Length);
+                        result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                        result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
+
+                        // Now munge a single byte of the checksum and ensure that the key no longer validates.
+                        keyBytes[CommonAnnotatedKey.ChecksumBytesIndex + i] = (byte)~keyBytes[CommonAnnotatedKey.ChecksumBytesIndex + i];
+
+                        // Having munged the checksum, the key should no longer validate.
+                        result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                        result.Should().BeFalse(because: $"{key}' should not validate using 'TryValidateCommonAnnotatedKey' when its checksum is altered");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IdentifiableSecrets_TryValidateCommonAnnotatedKeyBase62EncodedChecksums()
+        {
+            using var assertionScope = new AssertionScope();
+
+            for (int i = 0; i < 1; i++)
+            {
+                foreach (bool longForm in new[] { true, false })
+                {
+                    string signature = GetRandomSignature();
+                    string key = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature,
+                                                                                customerManagedKey: true,
+                                                                                new byte[9],
+                                                                                new byte[3],
+                                                                                longForm);
+
+                    byte[] keyBytes = Convert.FromBase64String(key);
+                    bool result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                    result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
+
+                    CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask);
+                    cask.Should().NotBeNull(because: $"the '{key}' should be a valid cask");
+
+                    byte[] originalChecksum = new byte[cask.ChecksumBytes.Length];
+                    Array.Copy(keyBytes, CommonAnnotatedKey.ChecksumBytesIndex, originalChecksum, 0, originalChecksum.Length);
+
+                    for (int j = 0; j < cask.ChecksumBytes.Length; j++)
+                    {
+                        // Ensure that the we've restored the key entirely
+                        Array.Copy(originalChecksum, 0, keyBytes, CommonAnnotatedKey.ChecksumBytesIndex, originalChecksum.Length);
+                        result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                        result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
+
+                        // Now munge a single byte of the checksum and ensure that the key no longer validates.
+                        keyBytes[CommonAnnotatedKey.ChecksumBytesIndex + i] = (byte)~keyBytes[CommonAnnotatedKey.ChecksumBytesIndex + i];
+
+                        // Having munged the checksum, the key should no longer validate.
+                        result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
+                        result.Should().BeFalse(because: $"{key}' should not validate using 'TryValidateCommonAnnotatedKey' when its checksum is altered");
+                    }
+                }
+            }
+        }
 
         [TestMethod]
         public void IdentifiableSecrets_ComputeCommonAnnotatedHashByteArrayOverloadsShouldFunction()
@@ -239,7 +425,7 @@ namespace Microsoft.Security.Utilities
         {
             using var assertionScope = new AssertionScope();
 
-            foreach (string invalidSignature in new[] { "AbAA", "aaaB", "1AAA" })
+            foreach (string invalidSignature in new[] { "AbAA", "aaaB", "1AAA", "A?AA" })
             {
                 var action = () => IdentifiableSecrets.ValidateCommonAnnotatedKeySignature(invalidSignature);
                 action.Should().Throw<ArgumentException>(because: $"the signature '{invalidSignature}' is invalid");
@@ -290,7 +476,7 @@ namespace Microsoft.Security.Utilities
             string textToHash = "NonsensitiveData";
 
             byte[] derivedKeyBytes = IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey(textToHash,
-                                                                                            Encoding.UTF8.GetBytes(key));
+                                                                                          Convert.FromBase64String(key));
 
             string derivedKey = IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey(textToHash, key);
 
@@ -308,11 +494,33 @@ namespace Microsoft.Security.Utilities
             string textToHash = "NonsensitiveData";
 
             byte[] computedHashBytes = IdentifiableSecrets.ComputeCommonAnnotatedHash(textToHash,
-                                                                                      Encoding.UTF8.GetBytes(key));
+                                                                                      Convert.FromBase64String(key));
 
             string computedHash = IdentifiableSecrets.ComputeCommonAnnotatedHash(textToHash, key);
 
             computedHash.Should().Be(Convert.ToBase64String(computedHashBytes), because: "the computed hash should match the byte array");
+        }
+
+        [TestMethod]
+        public void IdentifiableSecret_ComputeCommonAnnotatedHashFullOverload()
+        {
+            string key = IdentifiableSecrets.GenerateCommonAnnotatedKey("ABCD",
+                                                                        customerManagedKey: true,
+                                                                        new byte[9],
+                                                                        new byte[3]);
+
+            string textToHash = "NonsensitiveData";
+
+            byte[] secretBytes = Encoding.UTF8.GetBytes(textToHash);
+
+            IdentifiableSecrets.ComputeCommonAnnotatedHash(textToHash,
+                                                           secretBytes,
+                                                           "TEST",
+                                                           customerManagedKey: true,
+                                                           new byte[9], 
+                                                           new byte[3],
+                                                           longForm: false,
+                                                           keyKindSignature: 'D');
         }
 
         [TestMethod]
@@ -954,7 +1162,7 @@ namespace Microsoft.Security.Utilities
             return alphabet;
         }
 
-        private string GetReplacementCharacter(char ch)
+        private static string GetReplacementCharacter(char ch)
         {
             // Generate a replacement character that works for all possible
             // generated characters in secrets, whether or not they are encoded
@@ -965,6 +1173,20 @@ namespace Microsoft.Security.Utilities
             return Char.IsUpper(ch)
                 ? ch.ToString().ToLowerInvariant()
                 : ch.ToString().ToUpperInvariant();
+        }
+
+        private static string GetRandomSignature()
+        {
+            byte[] singleByte = new byte[1];
+            s_random.NextBytes(singleByte);
+
+            int character = (int)singleByte[0] %26;
+
+            s_random.NextBytes(singleByte);
+            bool isUpper = singleByte[0] % 2 == 0;
+            
+            string signature = $"{s_base62Alphabet[character]}{Guid.NewGuid().ToString("N").Substring(0, 3)}";
+            return isUpper ? signature.ToUpperInvariant() : signature.ToLowerInvariant();
         }
     }
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -5,14 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
-
-// Copyright(c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/Tests.Microsoft.Security.Utilities.Core/RE2RegexEngine.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/RE2RegexEngine.cs
@@ -2,14 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.RE2.Managed;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Security.Utilities
 {
+    [ExcludeFromCodeCoverage]
     public class RE2RegexEngine : IRegexEngine
     {
         public static IRegexEngine Instance = new RE2RegexEngine();

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -12,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Security.Utilities
 {
-    [TestClass]
+    [TestClass, ExcludeFromCodeCoverage]
     public class WellKnownRegexPatternsTests
     {
         /// <summary>

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellknownTestLiteralEncoders.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellknownTestLiteralEncoders.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace Microsoft.Security.Utilities
 {
+    [ExcludeFromCodeCoverage]
     public sealed class WellKnownTestLiteralEncoders
     {
         public static string EscapeJsonString(string value)


### PR DESCRIPTION
- BUG: Correct `IdentifiableSecrets` `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` helpers to preserve all randomized byte input entropy by encoding and decoding this data as base64.
- NEW: Add `CommonAnnotatedKey` `ChecksumBytes` and `ChecksumBytesIndex` convenience methods for retrieving key checksum data.

This change ensures that all byte[] randomized data is processed as base64 (rather than encoding and decoding as UTF8 a process that stripped entropy). This change includes testing that achieves effectively 100% code coverage (which will assist in future refactoring/simplification of code). 

Regrettably, I also noted that the `SecretMasker` test class had been commented out. As a result, tests have not been running for some period of time. I've fixed up some regressions that have accumulated but did not fix a condition in which some lower confidence findings produce duplicated results for the same test data. #95 opened to address this.