### PR TITLE
chore: fix build script for first-time run

### DIFF
--- a/scripts/BuildPackages.ps1
+++ b/scripts/BuildPackages.ps1
@@ -26,6 +26,7 @@ function Exit-WithFailureMessage($scriptName, $message) {
 }
 
 dotnet tool update --global nbgv --version 3.3.37
+$env:Path = "$env:Path;$env:USERPROFILE/.dotnet/tools"
 $tag = nbgv get-version --variable NugetPackageVersion
 
 if ($env:MsuiNugetPackageVersion) {


### PR DESCRIPTION
Prior to this, if the user running the script had never installed a dotnet tool before, they would get an error when the script attempted to use nbgv. Despite the script auto-installing it, if dotnet tool has never run before, it won't be on the PATH yet since dotnet tool mutates that PATH but it doesn't get refreshed within the same session.