### PR TITLE
CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey) raises unhandled exception

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,7 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
+# 1.9.0 - 09/24/2024
 
 # 1.8.0 - 09/16/2024
 - BUG: Mark `SEC000/000.Unclassified32ByteBase64String`, `SEC000/001.Unclassified64ByteBase64String`, `SEC101/101.AadClientAppLegacyCredentials`, `SEC000/001.Unclassified64ByteBase64String` as `DetectionMetadata.LowConfidence`.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- BUG: Fix unhandled exception raised by `CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey)` when passed non-CASK secrets of length < 80.
+
 # 1.9.0 - 09/24/2024
 
 # 1.8.0 - 09/16/2024

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -17,13 +17,14 @@ namespace Microsoft.Security.Utilities
             secret = null;
             string identifiableKey = key;
             ulong checksumSeed = IdentifiableSecrets.VersionTwoChecksumSeed;
-            string base64EncodedSignature = key.Substring(76, 4);
 
             if (key.Length != IdentifiableSecrets.StandardEncodedCommonAnnotatedKeySize &&
                 key.Length != IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize)
             {
                 return false;
             }
+
+            string base64EncodedSignature = key.Substring(76, 4);
 
             bool longForm = key.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize;
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/CommonAnnotatedKeyTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/CommonAnnotatedKeyTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Security.Utilities
+{
+    [TestClass, ExcludeFromCodeCoverage]
+    public class CommonAnnotatedKeyTests
+    {
+        [TestMethod]
+        public void CommonAnnotatedKey_TryCreateWithNonCaskSecret()
+        {
+            using var _ = new AssertionScope();
+
+            foreach (bool longForm in new[] { true, false })
+            {
+                string signature = "APIM";
+
+                string caskSecret = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature, customerManagedKey: true, null, null, longForm);
+                string legacySecret = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Trim('=');
+
+                foreach (string secret in new[] { caskSecret, legacySecret })
+                {
+                    var action = () => CommonAnnotatedKey.TryCreate(secret, out CommonAnnotatedKey cask);
+                    action.Should().NotThrow(because: "TryCreate should never throw");
+                }
+            }
+        }
+    }
+}

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -30,6 +30,32 @@ namespace Microsoft.Security.Utilities
         }
 
         private static string s_base62Alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+        [TestMethod]
+        public void IdentifiableSecrets_IdentifiableSecrets_ComputeCommonAnnotatedHash()
+        {
+            foreach (bool longForm in new[] { true, false })
+            {
+                string signature = GetRandomSignature();
+
+                string cask = IdentifiableSecrets.GenerateCommonAnnotatedKey(signature, customerManagedKey: true, null, null, longForm);
+                string legacySecret = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+
+                foreach (string secret in new[] { cask, legacySecret })
+                {
+                    string message = Guid.NewGuid().ToString();
+
+                    string hash = IdentifiableSecrets.ComputeCommonAnnotatedHash(message,
+                                                                                 Convert.FromBase64String(secret),
+                                                                                 signature,
+                                                                                 customerManagedKey: true,
+                                                                                 platformReserved: null,
+                                                                                 providerReserved: null,
+                                                                                 longForm);
+                }
+            }
+        }        
+
         [TestMethod]
         public void IdentifiableSecrets_GenerateCommonAnnotatedTestKey()
         {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.9.0-prerelease",
+  "version": "1.9.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- BUG: Fix unhandled exception raised by `CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey)` when passed non-CASK secrets of length < 80.

