### PR TITLE
CASK detection with prefix or suffix

### DIFF
--- a/src/Microsoft.Security.Utilities.Cli/ScanOptions.cs
+++ b/src/Microsoft.Security.Utilities.Cli/ScanOptions.cs
@@ -10,9 +10,14 @@ namespace Microsoft.Security.Utilities.Cli
         [Option(
             'i',
             "input",
-            Required = true,
             HelpText = "A path to a file to scan for identifiable secrets.")]
         public string Input { get; set; }
+
+        [Option(
+            's',
+            "string-input",
+            HelpText = "A path to a file to scan for identifiable secrets.")]
+        public string StringInput  { get; set; }
 
         [Option(
             "recurse",

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_190_AzureEventGridIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_190_AzureEventGridIdentifiableKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    public class AzureEventGridIdentifiableKey : Azure32ByteIdentifiableKey
+    public class AzureEventGridIdentifiableKey : CommonAnnotatedSecurityKey
     {
         public AzureEventGridIdentifiableKey()
         {
@@ -14,7 +14,5 @@ namespace Microsoft.Security.Utilities
         }
 
         public override ISet<string> Signatures => IdentifiableMetadata.AzureEventGridSignature.ToSet();
-
-        public override IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableSecrets.VersionTwoChecksumSeed };
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_190_AzureEventGridIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_190_AzureEventGridIdentifiableKey.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities
 {
-    public class AzureEventGridIdentifiableKey : CommonAnnotatedSecurityKey
+    public class AzureEventGridIdentifiableKey : Azure32ByteIdentifiableKey
     {
         public AzureEventGridIdentifiableKey()
         {
@@ -14,5 +14,7 @@ namespace Microsoft.Security.Utilities
         }
 
         public override ISet<string> Signatures => IdentifiableMetadata.AzureEventGridSignature.ToSet();
+
+        public override IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableSecrets.VersionTwoChecksumSeed };
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/200";
             Name = nameof(CommonAnnotatedSecurityKey);
             DetectionMetadata = DetectionMetadata.Identifiable;
-            Pattern = $"{WellKnownRegexPatterns.PrefixAllBase64}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
+            Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
             Signatures = "JQQJ9".ToSet();
         }
 


### PR DESCRIPTION
CASK keys with a prefix (such as `https://`) or suffix (such as `@github.com`) would fail detection. This PR fixes that, and adds a test for the same.