### PR TITLE
Fix mismatched Azure event grid identifiable key rule id

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -346,7 +346,7 @@
     "RegexNormalizedSignature": "AZEG",
     "KeyLength": 32,
     "EncodeForUrl": false,
-    "Id": "SEC101/190",
+    "Id": "SEC101/199",
     "Name": "AzureEventGridIdentifiableKey",
     "DetectionMetadata": "Identifiable"
   },

--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -319,7 +319,7 @@
   },
   {
     "Pattern": "(^|[^0-9a-z])(?<refine>oy2[a-p][0-9a-z]{15}[aq][0-9a-z]{11}[eu][bdfhjlnprtvxz357][a-p][0-9a-z]{11}[aeimquy4])([^aeimquy4]|$)",
-    "Id": "SEC101/030",
+    "Id": "SEC101/031",
     "Name": "NuGetApiKey",
     "Signatures": [
       "oy2"

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -376,7 +376,7 @@
     "RegexNormalizedSignature": "AZEG",
     "KeyLength": 32,
     "EncodeForUrl": false,
-    "Id": "SEC101/190",
+    "Id": "SEC101/199",
     "Name": "AzureEventGridIdentifiableKey",
     "DetectionMetadata": "Identifiable"
   },

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -319,7 +319,7 @@
   },
   {
     "Pattern": "(^|[^0-9a-z])(?<refine>oy2[a-p][0-9a-z]{15}[aq][0-9a-z]{11}[eu][bdfhjlnprtvxz357][a-p][0-9a-z]{11}[aeimquy4])([^aeimquy4]|$)",
-    "Id": "SEC101/030",
+    "Id": "SEC101/031",
     "Name": "NuGetApiKey",
     "Signatures": [
       "oy2"

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -23,6 +23,7 @@
 - BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).
 - BUG: Correct `IdentifiableSecrets` `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` helpers to preserve all randomized byte input entropy by encoding and decoding this data as base64.
 - BUG: Update `AzureEventGridIdentifiableKey` rule id to `SEC101/199` to be synced with source of the rule.
+- BUG: Update `NuGetApiKey` rule id to `SEC101/031` to be synced with source of the rule.
 - NEW: Add `CommonAnnotatedKey` `ChecksumBytes` and `ChecksumBytesIndex` convenience methods for retrieving key checksum data.
 - PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -13,6 +13,8 @@
 
 # UNRELEASED
 - BUG: Fix unhandled exception raised by `CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey)` when passed non-CASK secrets of length < 80.
+- BUG: Update `AzureEventGridIdentifiableKey` rule id to `SEC101/199` to be synced with source of the rule.
+- BUG: Update `NuGetApiKey` rule id to `SEC101/031` to be synced with source of the rule.
 
 # 1.9.0 - 09/24/2024
 
@@ -22,8 +24,6 @@
 - BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
 - BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).
 - BUG: Correct `IdentifiableSecrets` `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` helpers to preserve all randomized byte input entropy by encoding and decoding this data as base64.
-- BUG: Update `AzureEventGridIdentifiableKey` rule id to `SEC101/199` to be synced with source of the rule.
-- BUG: Update `NuGetApiKey` rule id to `SEC101/031` to be synced with source of the rule.
 - NEW: Add `CommonAnnotatedKey` `ChecksumBytes` and `ChecksumBytesIndex` convenience methods for retrieving key checksum data.
 - PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -22,6 +22,7 @@
 - BUG: Mark `SEC101/030.NuGetApiKey`, `SEC101/105.AzureMessageLegacyCredentials`, `SEC101/110.AzureDatabricksPat`,`SEC101/050.NpmAuthorKey`,`SEC101/565.SecretScanningSampleToken` as `DetectionMetadata.HighConfidence`.
 - BUG: Make round-tripping of common annotated security keys through base64 encoding/decoding more robust. We previously emitted illegal ending base64 characters (when appending base62 encoded checksums).
 - BUG: Correct `IdentifiableSecrets` `ComputeDerivedCommonAnnotatedKey` and `ComputeCommonAnnotatedHash` helpers to preserve all randomized byte input entropy by encoding and decoding this data as base64.
+- BUG: Update `AzureEventGridIdentifiableKey` rule id to `SEC101/199` to be synced with source of the rule.
 - NEW: Add `CommonAnnotatedKey` `ChecksumBytes` and `ChecksumBytesIndex` convenience methods for retrieving key checksum data.
 - PRF: Enable scan pre-filtering by declaring `.servicebus` as `SEC101/105.AzureMessageLegacyCredentials` signature.
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_031_NuGetApiKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_031_NuGetApiKey.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Security.Utilities
     {
         public NuGetApiKey()
         {
-            Id = "SEC101/030";
+            Id = "SEC101/031";
             Name = nameof(NuGetApiKey);
             DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy| DetectionMetadata.HighConfidence;
             Pattern = "(^|[^0-9a-z])(?<refine>oy2[a-p][0-9a-z]{15}[aq][0-9a-z]{11}[eu][bdfhjlnprtvxz357][a-p][0-9a-z]{11}[aeimquy4])([^aeimquy4]|$)";

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_199_AzureEventGridIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_199_AzureEventGridIdentifiableKey.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Security.Utilities
     {
         public AzureEventGridIdentifiableKey()
         {
-            Id = "SEC101/190";
+            Id = "SEC101/199";
             Name = nameof(AzureEventGridIdentifiableKey);
         }
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
@@ -48,7 +48,7 @@ namespace Tests.Microsoft.Security.Utilities.Core
         [TestMethod]
         public void IdentifiableScan_IdentifiableKeys()
         {
-            int iterations = 1000;
+            int iterations = 1;
 
             using var assertionScope = new AssertionScope();
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
@@ -48,7 +48,7 @@ namespace Tests.Microsoft.Security.Utilities.Core
         [TestMethod]
         public void IdentifiableScan_IdentifiableKeys()
         {
-            int iterations = 1;
+            int iterations = 1000;
 
             using var assertionScope = new AssertionScope();
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -529,7 +529,7 @@ impl ScanOptions {
 
         clone.defs.push(
             ScanDefinition::new(
-                "SEC101/190",
+                "SEC101/199",
                 b"AZEG",
                 b'A',
                 37,


### PR DESCRIPTION
# Description

- Update the rule id of `AzureEventGridIdentifiableKey` to `SEC101/199`.
- Update the rule id of `NuGetApiKey` to `SEC101/031`.