### PR TITLE
Removing base62 rust crate

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,8 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
+# 1.9.1 - 11/18/2024
+- DEP: Removed dependency of the `base-62` crate in the Rust codebase, since it depended on the `failure` crate which has a known [vulnerability](https://github.com/advisories/GHSA-jq66-xh47-j9f3).
 - BUG: Fix unhandled exception raised by `CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey)` when passed non-CASK secrets of length < 80.
 - BUG: Update `AzureEventGridIdentifiableKey` rule id to `SEC101/199` to be synced with source of the rule.
 - BUG: Update `NuGetApiKey` rule id to `SEC101/031` to be synced with source of the rule.

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -20,7 +20,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.9.0");
+        version.ToString().Should().Be("1.9.1");
     }
 
     [TestMethod]

--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base-62 = "0.1.1"
 base64 = "0.21.0"
 chrono = "0.4.38"
 lazy_static = "1.4.0"

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_secrets.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code)]
 #![allow(unused_assignments)]
 
-use base_62;
 use base64::{engine::general_purpose, Engine as _};
 use chrono::Datelike;
 use core::panic;
@@ -238,7 +237,7 @@ pub fn generate_common_annotated_test_key(
             let mut rng = rand::thread_rng();
             rng.try_fill_bytes(&mut key_bytes).expect("Failed to generate random bytes.");
 
-            key  = base_62::encode(&key_bytes);
+            key  = general_purpose::STANDARD.encode(&key_bytes);
 
             if key.len() < 86 {
                 return Err(format!("The key length is less than 86 characters: {}", key));

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
The `base62` Rust crate depended on the `failure` Rust crate, which has a [known vulnerability](https://github.com/advisories/GHSA-jq66-xh47-j9f3). 