### PR TITLE
Allow allocation time to be specified

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,9 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- BUG: Merge multiple calls to `DateTime.UtcNow` in `GenerateCommonAnnotatedKey`, forcing year and month to agree. Add overload to provide an arbitrary allocation time, with bound checks (year 2024 to 2085).
+
 # 1.9.1 - 11/18/2024
 - DEP: Removed dependency of the `base-62` crate in the Rust codebase, since it depended on the `failure` crate which has a known [vulnerability](https://github.com/advisories/GHSA-jq66-xh47-j9f3).
 - BUG: Fix unhandled exception raised by `CommonAnnotatedKey.TryCreate(string, out CommonAnnotatedKey)` when passed non-CASK secrets of length < 80.

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -373,7 +373,7 @@ public static class IdentifiableSecrets
         // An allocation time before 2024 or after 2085 is outside of the possible range a base62 character can express.
         if (allocationTime.Year < 2024 || allocationTime.Year > 2085)
         {
-            throw new ArgumentOutOfRangeException(nameof(allocationTime), "The allocation time year must between 2024 and 2085, inclusive.");
+            throw new ArgumentOutOfRangeException(nameof(allocationTime), "The allocation year must be between 2024 and 2085, inclusive.");
         }
 
         base64EncodedSignature = customerManagedKey

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -369,9 +369,11 @@ public static class IdentifiableSecrets
             throw new ArgumentException(nameof(allocationTime), "The allocation time must be in UTC.");
         }
 
-        if (allocationTime.Year < 2024)
+        // 2085 is 61 years after 2024. A base62 character is used to express the year (A = 2024 up to 9 = 2085).
+        // An allocation time before 2024 or after 2085 is outside of the possible range a base62 character can express.
+        if (allocationTime.Year < 2024 || allocationTime.Year > 2085)
         {
-            throw new ArgumentOutOfRangeException(nameof(allocationTime), "The allocation time year must be 2024 or later.");
+            throw new ArgumentOutOfRangeException(nameof(allocationTime), "The allocation time year must between 2024 and 2085, inclusive.");
         }
 
         base64EncodedSignature = customerManagedKey

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -314,6 +314,29 @@ public static class IdentifiableSecrets
                                                         char? testChar,
                                                         char keyKindSignature)
     {
+        return GenerateCommonAnnotatedTestKey(randomBytes,
+                                              checksumSeed,
+                                              base64EncodedSignature,
+                                              customerManagedKey,
+                                              platformReserved,
+                                              providerReserved,
+                                              longForm,
+                                              testChar,
+                                              keyKindSignature,
+                                              DateTime.UtcNow);
+    }
+
+    public static string GenerateCommonAnnotatedTestKey(byte[] randomBytes,
+                                                        ulong checksumSeed,
+                                                        string base64EncodedSignature,
+                                                        bool customerManagedKey,
+                                                        byte[] platformReserved,
+                                                        byte[] providerReserved,
+                                                        bool longForm,
+                                                        char? testChar,
+                                                        char keyKindSignature,
+                                                        DateTime allocationTime)
+    {
         const int platformReservedLength = 9;
         const int providerReservedLength = 3;
 
@@ -339,6 +362,16 @@ public static class IdentifiableSecrets
         if (providerReserved == null)
         {
             providerReserved = new byte[providerReservedLength];
+        }
+
+        if (allocationTime.Kind != DateTimeKind.Utc)
+        {
+            throw new ArgumentException(nameof(allocationTime), "The allocation time must be in UTC.");
+        }
+
+        if (allocationTime.Year < 2024)
+        {
+            throw new ArgumentOutOfRangeException(nameof(allocationTime), "The allocation time year must be 2024 or later.");
         }
 
         base64EncodedSignature = customerManagedKey
@@ -388,8 +421,8 @@ public static class IdentifiableSecrets
         keyBytes[keyBytes.Length - 23] = reservedBytes[0];
 
         // Simplistic timestamp computation.
-        byte yearsSince2024 = (byte)(DateTime.UtcNow.Year - 2024);
-        byte zeroIndexedMonth = (byte)(DateTime.UtcNow.Month - 1);
+        byte yearsSince2024 = (byte)(allocationTime.Year - 2024);
+        byte zeroIndexedMonth = (byte)(allocationTime.Month - 1);
 
         byte orgBits = 61; // Base64 encoding for '9'
         byte keyKindBits = (byte)(keyKindSignature == '9' ? 61 : keyKindSignature - 'A');


### PR DESCRIPTION
Also fix highly improbably timing bug where allocation year and month do not match.

This will allow NuGet to encode more specific allocation details that are consistent with the built-in year and month values.