### PR TITLE
Expose Value property on SecretLiteral

### DIFF
--- a/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
@@ -20,7 +20,7 @@
     "DetectionMetadata": "HighEntropy, MediumConfidence"
   },
   {
-    "Pattern": "(ftps?|https?):\\/\\/(?<refine>[^:@\\/]+:[^:@?\\/]+)@",
+    "Pattern": "($|\\b)(ftps?|https?):\\/\\/(?<refine>[^:@\\/]+:[^:@?\\/]+)@",
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
     "Signatures": [

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -11,7 +11,7 @@
     "DetectionMetadata": "HighEntropy, MediumConfidence"
   },
   {
-    "Pattern": "(ftps?|https?):\\/\\/(?<refine>[^:@\\/]+:[^:@?\\/]+)@",
+    "Pattern": "($|\\b)(ftps?|https?):\\/\\/(?<refine>[^:@\\/]+:[^:@?\\/]+)@",
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
     "Signatures": [

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,10 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# 1.11.0 - 01/02/2025
+- NEW: Expose `SecretLiteral.Value` as public data.
+- FPS: Update `SEC101/127.UrlCredentials` regex to require a word break before the `ftp` or `http` schema rendering.
+
 # 1.10.0 - 01/01/2025
 - BRK: Update `SEC101/127.UrlCredentials` match refinement to include both the account name and password. This is a breaking change as the correlating id will differ.
 - BUG: Merge multiple calls to `DateTime.UtcNow` in `GenerateCommonAnnotatedKey`, forcing year and month to agree. Add overload to provide an arbitrary allocation time, with bound checks (year 2024 to 2085).

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -15,7 +15,7 @@
 - NEW: Expose `SecretLiteral.Value` as public data.
 - FPS: Update `SEC101/127.UrlCredentials` regex to require a word break before the `ftp` or `http` schema rendering.
 
-# 1.10.0 - 01/01/2025
+# 1.10.0 - 01/02/2025
 - BRK: Update `SEC101/127.UrlCredentials` match refinement to include both the account name and password. This is a breaking change as the correlating id will differ.
 - BUG: Merge multiple calls to `DateTime.UtcNow` in `GenerateCommonAnnotatedKey`, forcing year and month to agree. Add overload to provide an arbitrary allocation time, with bound checks (year 2024 to 2085).
 - BUG: Mark `SecretMasker(SecretMasker)` copy contructor as protected to make it callable by derived classes.

--- a/src/Microsoft.Security.Utilities.Core/SecretLiteral.cs
+++ b/src/Microsoft.Security.Utilities.Core/SecretLiteral.cs
@@ -14,7 +14,7 @@ public class SecretLiteral
 
     public SecretLiteral(string value)
     {
-        m_value = value ?? throw new ArgumentNullException(nameof(value));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     public override bool Equals(object? obj)
@@ -24,10 +24,10 @@ public class SecretLiteral
         {
             return false;
         }
-        return string.Equals(m_value, item.m_value, StringComparison.Ordinal);
+        return string.Equals(Value, item.Value, StringComparison.Ordinal);
     }
 
-    public override int GetHashCode() => m_value.GetHashCode();
+    public override int GetHashCode() => Value.GetHashCode();
 
     public IEnumerable<Detection> GetDetections(string input, string redactionToken)
     {
@@ -36,20 +36,20 @@ public class SecretLiteral
             redactionToken = FallbackRedactionToken;
         }
 
-        if (!string.IsNullOrEmpty(input) && !string.IsNullOrEmpty(m_value))
+        if (!string.IsNullOrEmpty(input) && !string.IsNullOrEmpty(Value))
         {
             int startIndex = 0;
             while (startIndex > -1 &&
                    startIndex < input.Length &&
-                   input.Length - startIndex >= m_value.Length) // remaining substring longer than secret value
+                   input.Length - startIndex >= Value.Length) // remaining substring longer than secret value
             {
-                startIndex = input.IndexOf(m_value, startIndex, StringComparison.Ordinal);
+                startIndex = input.IndexOf(Value, startIndex, StringComparison.Ordinal);
                 if (startIndex > -1)
                 {
                     yield return new Detection(id: null,
                                                name: null,
                                                start: startIndex,
-                                               length: m_value.Length,
+                                               length: Value.Length,
                                                metadata: 0,
                                                rotationPeriod: default,
                                                crossCompanyCorrelatingId: null,
@@ -60,5 +60,5 @@ public class SecretLiteral
         }
     }
 
-    internal readonly string m_value;
+    public string Value { get; private set; }
 }

--- a/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
+++ b/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
@@ -312,7 +312,7 @@ public class SecretMasker : ISecretMasker, IDisposable
         var encodedSecrets = new List<SecretLiteral>();
         foreach (SecretLiteral originalSecret in originalSecrets)
         {
-            string encodedValue = encoder(originalSecret.m_value);
+            string encodedValue = encoder(originalSecret.Value);
             if (!string.IsNullOrEmpty(encodedValue) && encodedValue.Length >= MinimumSecretLength)
             {
                 encodedSecrets.Add(new SecretLiteral(encodedValue));

--- a/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
@@ -14,7 +14,7 @@ public sealed class UrlCredentials : RegexPattern
 
         Name = nameof(UrlCredentials);
 
-        Pattern = @"(ftps?|https?):\/\/(?<refine>[^:@\/]+:[^:@?\/]+)@";
+        Pattern = @"($|\b)(ftps?|https?):\/\/(?<refine>[^:@\/]+:[^:@?\/]+)@";
 
         DetectionMetadata = DetectionMetadata.MediumConfidence;
 

--- a/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/UrlCredentials.cs
@@ -50,6 +50,8 @@ public sealed class UrlCredentials : RegexPattern
         {
             $"http://example.com/embedded:colon",
             $"ftp://@example.com/embedded:colon",
+            $"prefixedftp://@example.com/embedded:colon",
+            $"prefixedhttps://@example.com/embedded:colon",
         };
     }
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -20,7 +20,7 @@ public class SecretMaskerTests
     public void SecretMasker_Version()
     {
         Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.10.0");
+        version.ToString().Should().Be("1.11.0");
     }
 
     [TestMethod]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
# 1.11.0 - 01/02/2025
- NEW: Expose `SecretLiteral.Value` as public data.
- FPS: Update `SEC101/127.UrlCredentials` regex to require a word break before the `ftp` or `http` schema rendering.