### PR TITLE
Fix bugs related to erroneous or incorrectly interpreted suffix and prefixes.

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -9,7 +9,7 @@
     "DetectionMetadata": "Identifiable"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.+/=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{3}(7|8)Q~[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{31,34})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.+/=]|$)",
+    "Pattern": "(^|[^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/])(?<refine>[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{3}(7|8)Q~[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{31,34})([^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/]|$)",
     "Id": "SEC101/156",
     "Name": "AadClientAppIdentifiableCredentials",
     "Signatures": [
@@ -28,7 +28,7 @@
       5575864757416767536,
       6014965721085063216
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]|$)",
     "KeyLength": 40,
     "RegexNormalizedSignature": "AzFu",
     "Id": "SEC101/158",
@@ -43,7 +43,7 @@
     "ChecksumSeeds": [
       5869709231681187888
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "AzSe",
     "Id": "SEC101/166",
@@ -58,7 +58,7 @@
     "Signatures": [
       "AzSe"
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "AzSe",
     "Id": "SEC101/167",
@@ -74,7 +74,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ARm",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -91,7 +91,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+AEh",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -108,7 +108,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ASb",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -123,7 +123,7 @@
     "ChecksumSeeds": [
       5291540757367369776
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -138,7 +138,7 @@
     "ChecksumSeeds": [
       4928475562238095408
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -153,7 +153,7 @@
     "ChecksumSeeds": [
       4931568359632875568
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -169,7 +169,7 @@
       4928457935994778672
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ASt",
     "EncodeForUrl": false,
     "Id": "SEC101/152",
@@ -190,7 +190,7 @@
       6014965720764854320
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "ACDb",
     "EncodeForUrl": false,
     "Id": "SEC101/160",
@@ -205,7 +205,7 @@
       4711400055309086768
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ABa",
     "EncodeForUrl": false,
     "Id": "SEC101/163",
@@ -220,7 +220,7 @@
       4858365246511342384
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+AMC",
     "EncodeForUrl": false,
     "Id": "SEC101/170",
@@ -235,7 +235,7 @@
       6081388236577714224
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/181",
@@ -250,7 +250,7 @@
       5291540757367369776
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/182",
@@ -265,7 +265,7 @@
       5143520228578766896
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/183",
@@ -280,7 +280,7 @@
       5145771916421312560
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/184",
@@ -294,7 +294,7 @@
     "ChecksumSeeds": [
       4711718922539446320
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AzCa",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -309,7 +309,7 @@
     "ChecksumSeeds": [
       4702692889634567216
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "\\+ACR",
     "EncodeForUrl": false,
@@ -343,7 +343,7 @@
     "ChecksumSeeds": [
       4928457935994778672
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AZEG",
     "KeyLength": 32,
     "EncodeForUrl": false,

--- a/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_~.+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_~.+/=]|$)",
+    "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
     "Signatures": [
@@ -17,21 +17,21 @@
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{34}$",
+    "Pattern": "^[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{34}$",
     "Id": "SEC101/101",
     "Name": "AadClientAppLegacyCredentials",
     "Signatures": null,

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -9,7 +9,7 @@
     "DetectionMetadata": "Identifiable"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.+/=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{3}(7|8)Q~[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{31,34})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.+/=]|$)",
+    "Pattern": "(^|[^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/])(?<refine>[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{3}(7|8)Q~[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{31,34})([^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/]|$)",
     "Id": "SEC101/156",
     "Name": "AadClientAppIdentifiableCredentials",
     "Signatures": [
@@ -28,7 +28,7 @@
       5575864757416767536,
       6014965721085063216
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]|$)",
     "KeyLength": 40,
     "RegexNormalizedSignature": "AzFu",
     "Id": "SEC101/158",
@@ -43,7 +43,7 @@
     "ChecksumSeeds": [
       5869709231681187888
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "AzSe",
     "Id": "SEC101/166",
@@ -58,7 +58,7 @@
     "Signatures": [
       "AzSe"
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "AzSe",
     "Id": "SEC101/167",
@@ -74,7 +74,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ARm",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -91,7 +91,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+AEh",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -108,7 +108,7 @@
       5506058963192262704,
       5575859178286952496
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ASb",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -123,7 +123,7 @@
     "ChecksumSeeds": [
       5291540757367369776
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -138,7 +138,7 @@
     "ChecksumSeeds": [
       4928475562238095408
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -153,7 +153,7 @@
     "ChecksumSeeds": [
       4931568359632875568
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AIoT",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -169,7 +169,7 @@
       4928457935994778672
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ASt",
     "EncodeForUrl": false,
     "Id": "SEC101/152",
@@ -190,7 +190,7 @@
       6014965720764854320
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "ACDb",
     "EncodeForUrl": false,
     "Id": "SEC101/160",
@@ -205,7 +205,7 @@
       4711400055309086768
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+ABa",
     "EncodeForUrl": false,
     "Id": "SEC101/163",
@@ -220,7 +220,7 @@
       4858365246511342384
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "\\+AMC",
     "EncodeForUrl": false,
     "Id": "SEC101/170",
@@ -235,7 +235,7 @@
       6081388236577714224
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/181",
@@ -250,7 +250,7 @@
       5291540757367369776
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/182",
@@ -265,7 +265,7 @@
       5143520228578766896
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/183",
@@ -280,7 +280,7 @@
       5145771916421312560
     ],
     "KeyLength": 64,
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "APIM",
     "EncodeForUrl": false,
     "Id": "SEC101/184",
@@ -294,7 +294,7 @@
     "ChecksumSeeds": [
       4711718922539446320
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AzCa",
     "KeyLength": 32,
     "EncodeForUrl": false,
@@ -309,7 +309,7 @@
     "ChecksumSeeds": [
       4702692889634567216
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "KeyLength": 39,
     "RegexNormalizedSignature": "\\+ACR",
     "EncodeForUrl": false,
@@ -373,7 +373,7 @@
     "ChecksumSeeds": [
       4928457935994778672
     ],
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "RegexNormalizedSignature": "AZEG",
     "KeyLength": 32,
     "EncodeForUrl": false,

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -31,7 +31,7 @@
     "DetectionMetadata": "HighEntropy, MediumConfidence"
   },
   {
-    "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_~.+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_~.+/=]|$)",
+    "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
     "Signatures": [
@@ -48,21 +48,21 @@
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/-_=])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
     "Signatures": null,
     "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence"
   },
   {
-    "Pattern": "^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\\-_~.]{34}$",
+    "Pattern": "^[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{34}$",
     "Id": "SEC101/101",
     "Name": "AadClientAppLegacyCredentials",
     "Signatures": null,

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,10 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# 1.13.0 - UNRELEASED
+- FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.
+- FNS: Eliminate false negatives resulting from improper use of the `-` character in regexes (where it was interpreted as a range operator not a literal).,
+
 # 1.12.0 - 01/06/2025
 - BRK: Derived keys and hashed data are no longer supported. The following API are removed:
   - `IdentifiableSecrets.CommonAnnotatedDerivedKeySignature`

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/IdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/IdentifiableKey.cs
@@ -53,14 +53,36 @@ namespace Microsoft.Security.Utilities
                     string encoded = new string(alphabet[i], encodedLength);
                     Array.Copy(Convert.FromBase64String(encoded), bytes, KeyLength);
 
-                    yield return
+                    string key =
                         IdentifiableSecrets.GenerateBase64KeyHelper(checksumSeed,
                                                                     keyLengthInBytes: KeyLength,
                                                                     Signatures!.First(),
                                                                     EncodeForUrl,
                                                                     bytes);
+
+                    yield return key;
+
+                    foreach (string prefix in s_nonInvalidatingPrefixes)
+                    {
+                        yield return $"{prefix}{key}";
+                    }
+
+                    foreach (string suffix in s_nonInvalidatingSuffixes)
+                    {
+                        yield return $"{key}{suffix}";
+                    }
                 }
             }
         }
+
+        private static readonly string[] s_nonInvalidatingPrefixes = new[]
+        {
+            "=",
+        };
+
+        private static readonly string[] s_nonInvalidatingSuffixes = new[]
+        {
+            ";",
+        };
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_152_AzureStorageAccountIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_152_AzureStorageAccountIdentifiableKey.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Security.Utilities
             // specifically, it looks for a key embedded in a connection string. We have had
             // misses previously due to mismanaging delimiters around the identifiable key
             // rules, so we will obtain the legacy rule patterns, replace their secret with
-            // and identifiable one, and ensure this rule continues to function against a very
+            // an identifiable one, and ensure this rule continues to function against a very
             // typical expression of this credential kind.
             foreach (string example in legacyStorageAccountKey.GenerateTruePositiveExamples())
             {

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_152_AzureStorageAccountIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_152_AzureStorageAccountIdentifiableKey.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Security.Utilities
 {
@@ -16,5 +17,35 @@ namespace Microsoft.Security.Utilities
         public override ISet<string> Signatures => IdentifiableMetadata.AzureStorageSignature.ToSet();
 
         public override IEnumerable<ulong> ChecksumSeeds => new[] { IdentifiableMetadata.AzureStorageAccountChecksumSeed };
+
+        public override IEnumerable<string> GenerateTruePositiveExamples()
+        {
+            string sampleKey = string.Empty;
+
+            foreach (string example in base.GenerateTruePositiveExamples())
+            {
+                sampleKey = example;
+                yield return example;
+            }
+
+            var legacyStorageAccountKey = new AzureStorageAccountLegacyCredentials();
+
+            // The legacy storage account key rule requires more context in the scan contents,
+            // specifically, it looks for a key embedded in a connection string. We have had
+            // misses previously due to mismanaging delimiters around the identifiable key
+            // rules, so we will obtain the legacy rule patterns, replace their secret with
+            // and identifiable one, and ensure this rule continues to function against a very
+            // typical expression of this credential kind.
+            foreach (string example in legacyStorageAccountKey.GenerateTruePositiveExamples())
+            {
+                string standaloneSecret =
+                        CachedDotNetRegex.Instance.Matches(example,
+                                                           legacyStorageAccountKey.Pattern,
+                                                           captureGroup: "refine").First().Value;
+
+                string generatedExample = example.Replace(standaloneSecret, sampleKey);
+                yield return generatedExample;
+            }
+        }
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Security.Utilities
 
                     yield return key;
 
-
                     foreach (string prefix in s_nonInvalidatingPrefixes)
                     {
                         yield return $"{prefix}{key}";

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -25,24 +25,45 @@ namespace Microsoft.Security.Utilities
                 {
                     char testChar = CustomAlphabetEncoder.DefaultBase62Alphabet[i];
 
-                    string example = null;
+                    string key = null;
 
                     foreach (char keyKindSignature in new[] { '9', 'D', 'H' })
                     {
-                        example = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(randomBytes: null,
-                                                                                     IdentifiableSecrets.VersionTwoChecksumSeed,
-                                                                                     "TEST",
-                                                                                     customerManagedKey: true,
-                                                                                     platformReserved: null,
-                                                                                     providerReserved: null,
-                                                                                     longForm,
-                                                                                     testChar,
-                                                                                     keyKindSignature);
+                        key = IdentifiableSecrets.GenerateCommonAnnotatedTestKey(randomBytes: null,
+                                                                                 IdentifiableSecrets.VersionTwoChecksumSeed,
+                                                                                 "TEST",
+                                                                                 customerManagedKey: true,
+                                                                                 platformReserved: null,
+                                                                                 providerReserved: null,
+                                                                                 longForm,
+                                                                                 testChar,
+                                                                                 keyKindSignature);
                     }
 
-                    yield return example;
+                    yield return key;
+
+
+                    foreach (string prefix in s_nonInvalidatingPrefixes)
+                    {
+                        yield return $"{prefix}{key}";
+                    }
+
+                    foreach (string suffix in s_nonInvalidatingSuffixes)
+                    {
+                        yield return $"{key}{suffix}";
+                    }
                 }
             }
         }
+
+        private static readonly string[] s_nonInvalidatingPrefixes = new[]
+        {
+            "=",
+        };
+
+        private static readonly string[] s_nonInvalidatingSuffixes = new[]
+        {
+            ";",
+        };
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -179,8 +179,8 @@ public static class WellKnownRegexPatterns
     public const string PrefixUrlSafeBase64 = $"({Start}|[^{RegexEncodedUrlSafeBase64}])";
     public const string SuffixUrlSafeBase64 = $"([^{RegexEncodedUrlSafeBase64}]|{End})";
 
-    public const string PrefixUrlUnreserved = $"({Start}|[^{RegexEncodedUrlUnreserved}+/=])";
-    public const string SuffixUrlUnreserved = $"([^{RegexEncodedUrlUnreserved}+/=]|{End})";
+    public const string PrefixUrlUnreserved = $"({Start}|[^{RegexEncodedUrlUnreserved}+/])";
+    public const string SuffixUrlUnreserved = $"([^{RegexEncodedUrlUnreserved}+/]|{End})";
     public const string PrefixBase62 = $"({Start}|[^{Base62}])";
     public const string SuffixBase62 = $"([^{Base62}]|{End})";
     public const string PrefixAllBase64 = @$"({Start}|[^{Base64}_\-])";

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -128,6 +128,9 @@ public static class WellKnownRegexPatterns
     {
         alphabet = alphabet ?? throw new ArgumentNullException(nameof(alphabet));
 
+        // Normalized escaped hyphens.
+        alphabet = alphabet.Replace(@"\-", "-");
+
         s_stringBuilder ??= new StringBuilder();
 
         s_stringBuilder.Length = 0;
@@ -175,7 +178,7 @@ public static class WellKnownRegexPatterns
     private const string Start = "^";
 
     public const string RegexEncodedUrlSafeBase64 = @$"{Base62}_\-";
-    public const string RegexEncodedUrlUnreserved = @$"{RegexEncodedUrlSafeBase64}~.";
+    public const string RegexEncodedUrlUnreserved = @$"~.{RegexEncodedUrlSafeBase64}";
     public const string PrefixUrlSafeBase64 = $"({Start}|[^{RegexEncodedUrlSafeBase64}])";
     public const string SuffixUrlSafeBase64 = $"([^{RegexEncodedUrlSafeBase64}]|{End})";
 

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -168,13 +168,13 @@ public static class WellKnownRegexPatterns
     public const string Alpha = $"{Lowercase}{Uppercase}";
     public const string Base62 = $"{Alpha}{Digit}";
     public const string Base64 = $"{Base62}+/";
-    public const string UrlSafeBase64 = $"{Base62}-_";
-    public const string UrlUnreserved = $"{Base62}-_~.";
+    public const string UrlSafeBase64 = $"{Base62}_-";
+    public const string UrlUnreserved = $"{Base62}_~.-";
 
     private const string End = "$";
     private const string Start = "^";
 
-    public const string RegexEncodedUrlSafeBase64 = @$"{Base62}\-_";
+    public const string RegexEncodedUrlSafeBase64 = @$"{Base62}\_-";
     public const string RegexEncodedUrlUnreserved = @$"{RegexEncodedUrlSafeBase64}~.";
     public const string PrefixUrlSafeBase64 = $"({Start}|[^{RegexEncodedUrlSafeBase64}])";
     public const string SuffixUrlSafeBase64 = $"([^{RegexEncodedUrlSafeBase64}]|{End})";
@@ -183,8 +183,8 @@ public static class WellKnownRegexPatterns
     public const string SuffixUrlUnreserved = $"([^{RegexEncodedUrlUnreserved}+/=]|{End})";
     public const string PrefixBase62 = $"({Start}|[^{Base62}])";
     public const string SuffixBase62 = $"([^{Base62}]|{End})";
-    public const string PrefixAllBase64 = $"({Start}|[^{Base64}-_=])";
-    public const string SuffixAllBase64 = $"([^{Base64}-_=]|{End})";
+    public const string PrefixAllBase64 = $"({Start}|[^{Base64}_-])";
+    public const string SuffixAllBase64 = $"([^{Base64}_=-]|{End})";
     public const string PrefixHexadecimal = $"({Start}|[^{Hexadecimal}])";
     public const string SuffixHexadecimal = $"([^{Hexadecimal}]|{End})";
 }

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -158,7 +158,7 @@ public static class WellKnownRegexPatterns
     private const string SparseAlpha = $"{SparseLowercase}{sparseUppercase}";
     private const string SparseBase62 = $"{SparseAlpha}{SparseDigit}";
     private const string SparseBase64 = $"{SparseBase62}+"; // Forward slash elided.
-    private const string SparseUrlSafeBase64 = $"{SparseBase62}-"; // Underscore elided.
+    private const string SparseUrlSafeBase64 = @$"{SparseBase62}\-"; // Underscore elided.
     private const string SparseUrlUnreserved = $"{SparseUrlSafeBase64}~"; // Period elided.
 
     public const string Digit = "1234567890";
@@ -168,13 +168,13 @@ public static class WellKnownRegexPatterns
     public const string Alpha = $"{Lowercase}{Uppercase}";
     public const string Base62 = $"{Alpha}{Digit}";
     public const string Base64 = $"{Base62}+/";
-    public const string UrlSafeBase64 = $"{Base62}_-";
-    public const string UrlUnreserved = $"{Base62}_~.-";
+    public const string UrlSafeBase64 = @$"{Base62}_\-";
+    public const string UrlUnreserved = @$"{Base62}_~.\-";
 
     private const string End = "$";
     private const string Start = "^";
 
-    public const string RegexEncodedUrlSafeBase64 = @$"{Base62}\_-";
+    public const string RegexEncodedUrlSafeBase64 = @$"{Base62}_\-";
     public const string RegexEncodedUrlUnreserved = @$"{RegexEncodedUrlSafeBase64}~.";
     public const string PrefixUrlSafeBase64 = $"({Start}|[^{RegexEncodedUrlSafeBase64}])";
     public const string SuffixUrlSafeBase64 = $"([^{RegexEncodedUrlSafeBase64}]|{End})";
@@ -183,8 +183,8 @@ public static class WellKnownRegexPatterns
     public const string SuffixUrlUnreserved = $"([^{RegexEncodedUrlUnreserved}+/=]|{End})";
     public const string PrefixBase62 = $"({Start}|[^{Base62}])";
     public const string SuffixBase62 = $"([^{Base62}]|{End})";
-    public const string PrefixAllBase64 = $"({Start}|[^{Base64}_-])";
-    public const string SuffixAllBase64 = $"([^{Base64}_=-]|{End})";
+    public const string PrefixAllBase64 = @$"({Start}|[^{Base64}_\-])";
+    public const string SuffixAllBase64 = @$"([^{Base64}_=\-]|{End})";
     public const string PrefixHexadecimal = $"({Start}|[^{Hexadecimal}])";
     public const string SuffixHexadecimal = $"([^{Hexadecimal}]|{End})";
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -781,7 +781,7 @@ namespace Microsoft.Security.Utilities
                     continue;
                 }
 
-                foreach (string securityKey in pattern.GenerateTruePositiveExamples())
+                foreach (string example in pattern.GenerateTruePositiveExamples())
                 {
                     IIdentifiableKey identifiablePattern = pattern as IIdentifiableKey;
                     if (identifiablePattern == null) { continue; }
@@ -792,14 +792,19 @@ namespace Microsoft.Security.Utilities
                     {
                         foreach (string signature in identifiablePattern.Signatures)
                         {
-                            if (IdentifiableSecrets.TryValidateBase64Key(securityKey, checksumSeed, signature, identifiablePattern.EncodeForUrl))
+                            string standaloneSecret =
+                                CachedDotNetRegex.Instance.Matches(example,
+                                                                   pattern.Pattern,
+                                                                   captureGroup: "refine").First().Value;
+
+                            if (IdentifiableSecrets.TryValidateBase64Key(standaloneSecret, checksumSeed, signature, identifiablePattern.EncodeForUrl))
                             {
                                 matched = true;
                                 string textToSign = $"{Guid.NewGuid()}";
 
                                 foreach (ulong derivedChecksumSeed in new[] { checksumSeed, ~checksumSeed })
                                 {
-                                    string derivedKey = IdentifiableSecrets.ComputeDerivedIdentifiableKey(textToSign, securityKey, checksumSeed, derivedChecksumSeed, identifiablePattern.EncodeForUrl);
+                                    string derivedKey = IdentifiableSecrets.ComputeDerivedIdentifiableKey(textToSign, standaloneSecret, checksumSeed, derivedChecksumSeed, identifiablePattern.EncodeForUrl);
                                     bool isValid = IdentifiableSecrets.TryValidateBase64Key(derivedKey, derivedChecksumSeed, signature);
                                     isValid.Should().BeTrue(because: $"the '{pattern.Name} derived key '{derivedKey}' should validate");
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -152,14 +152,14 @@ public class SecretMaskerTests
     private void ValidateSecurityModelsMasking(IEnumerable<RegexPattern> patterns, IRegexEngine engine, bool lowEntropyModels)
 
     {
-        using var assertionScope = new AssertionScope();
-
         // These tests generate randomized values. It may be useful to
         // bump up the # of iterations on an ad hoc basis to flush
         // out non-deterministic failures (typically based on the
         // characters chosen from the secret alphabet for the pattern).
         for (int i = 0; i < 1; i++)
         {
+            using var assertionScope = new AssertionScope();
+
             foreach (IRegexEngine regexEngine in new[] { RE2RegexEngine.Instance, CachedDotNetRegex.Instance })
             {
                 foreach (bool generateCrossCompanyCorrelatingIds in new[] { true, false })

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -159,7 +159,6 @@ public class SecretMaskerTests
         for (int i = 0; i < 1; i++)
         {
             using var assertionScope = new AssertionScope();
-
             foreach (IRegexEngine regexEngine in new[] { RE2RegexEngine.Instance, CachedDotNetRegex.Instance })
             {
                 foreach (bool generateCrossCompanyCorrelatingIds in new[] { true, false })
@@ -179,14 +178,14 @@ public class SecretMaskerTests
                             bool result = detection != null;
                             result.Should().BeTrue(because: $"'{testExample}' should contain a secret detected by at least one rule");
 
-                            string secretValue = testExample.Substring(detection.Start, detection.Length);
+                            string standaloneSecret = testExample.Substring(detection.Start, detection.Length);
 
-                            string moniker = pattern.GetMatchMoniker(secretValue);
+                            string moniker = pattern.GetMatchMoniker(standaloneSecret);
 
                             // 1. All generated test patterns should be detected by the masker.
                             string redacted = secretMasker.MaskSecrets(testExample);
                             result = redacted.Equals(testExample);
-                            result.Should().BeFalse(because: $"'{secretValue}' for '{moniker}' should be redacted from scan text");
+                            result.Should().BeFalse(because: $"'{standaloneSecret}' for '{moniker}' should be redacted from scan text");
 
                             // TODO: the generated examples don't distinguish the secret from surrounding context,
                             // for rules such as our connection string detecting logic. We need a future change to
@@ -198,7 +197,7 @@ public class SecretMaskerTests
                             }
 
                             string expectedRedactedValue = generateCrossCompanyCorrelatingIds
-                                ? $"{pattern.Id}:{RegexPattern.GenerateCrossCompanyCorrelatingId(secretValue)}" 
+                                ? $"{pattern.Id}:{RegexPattern.GenerateCrossCompanyCorrelatingId(standaloneSecret)}" 
                                 : RegexPattern.FallbackRedactionToken;
 
                             redacted.Should().Contain(expectedRedactedValue, because: $"generate correlating ids == {generateCrossCompanyCorrelatingIds}");

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Remoting.Contexts;
 
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Remoting.Contexts;
 
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -45,7 +46,13 @@ namespace Microsoft.Security.Utilities
                 {
                     foreach (string example in pattern.GenerateTruePositiveExamples())
                     {
-                        string moniker = pattern.GetMatchMoniker(example);
+                        string standaloneSecret =
+                            CachedDotNetRegex.Instance.Matches(example,
+                                                               pattern.Pattern,
+                                                               captureGroup: "refine").First().Value;
+
+
+                        string moniker = pattern.GetMatchMoniker(standaloneSecret);
 
                         if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
                             pattern.DetectionMetadata.HasFlag(DetectionMetadata.MediumConfidence) ||
@@ -85,7 +92,12 @@ namespace Microsoft.Security.Utilities
                 {
                     foreach (string example in pattern.GenerateTruePositiveExamples())
                     {
-                        string moniker = pattern.GetMatchMoniker(example);
+                        string standaloneSecret =
+                            CachedDotNetRegex.Instance.Matches(example, 
+                                                               pattern.Pattern, 
+                                                               captureGroup: "refine").First().Value;
+
+                        string moniker = pattern.GetMatchMoniker(standaloneSecret);
 
                         if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
                             (pattern.Signatures != null && pattern.Signatures.Any()))
@@ -123,7 +135,12 @@ namespace Microsoft.Security.Utilities
                 {
                     foreach (string example in pattern.GenerateTruePositiveExamples())
                     {
-                        wellKnownMonikers.Add(pattern.GetMatchMoniker(example));
+                        string standaloneSecret =
+                            CachedDotNetRegex.Instance.Matches(example,
+                                                               pattern.Pattern,
+                                                               captureGroup: "refine").First().Value;
+
+                        wellKnownMonikers.Add(pattern.GetMatchMoniker(standaloneSecret));
                     }
                 }
             }
@@ -143,7 +160,12 @@ namespace Microsoft.Security.Utilities
 
                 foreach (string example in pattern.GenerateTruePositiveExamples())
                 {
-                    string moniker = pattern.GetMatchMoniker(example);
+                    string standaloneSecret =
+                        CachedDotNetRegex.Instance.Matches(example,
+                                                           pattern.Pattern,
+                                                           captureGroup: "refine").First().Value;
+
+                    string moniker = pattern.GetMatchMoniker(standaloneSecret);
                     if (!wellKnownMonikers.Contains(moniker))
                     {
                         unrecognizedMonikers.Add(moniker);

--- a/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/WellKnownRegexPatternsTests.cs
@@ -31,90 +31,96 @@ namespace Microsoft.Security.Utilities
         [TestMethod]
         public void WellKnownRegexPatterns_EnsureAllPatternsExpressConfidence()
         {
-            using var assertionScope = new AssertionScope();
-
-            var rulesets = new[]{
-                WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
-                WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
-            };
-
-            var missingConfidence = new List<string>();
-
-            foreach (IEnumerable<RegexPattern> ruleset in rulesets)
+            for (int i = 0; i < 1000; i++)
             {
-                foreach (RegexPattern pattern in ruleset)
+                using var assertionScope = new AssertionScope();
+
+                var rulesets = new[] {
+                    WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
+                    WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
+                };
+
+                var missingConfidence = new List<string>();
+
+                foreach (IEnumerable<RegexPattern> ruleset in rulesets)
                 {
-                    foreach (string example in pattern.GenerateTruePositiveExamples())
+                    foreach (RegexPattern pattern in ruleset)
                     {
-                        string standaloneSecret =
-                            CachedDotNetRegex.Instance.Matches(example,
-                                                               pattern.Pattern,
-                                                               captureGroup: "refine").First().Value;
-
-
-                        string moniker = pattern.GetMatchMoniker(standaloneSecret);
-
-                        if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
-                            pattern.DetectionMetadata.HasFlag(DetectionMetadata.MediumConfidence) ||
-                            pattern.DetectionMetadata.HasFlag(DetectionMetadata.HighConfidence))
+                        foreach (string example in pattern.GenerateTruePositiveExamples())
                         {
-                            continue;
+                            string standaloneSecret =
+                                CachedDotNetRegex.Instance.Matches(example,
+                                                                   pattern.Pattern,
+                                                                   captureGroup: "refine").First().Value;
+
+
+                            string moniker = pattern.GetMatchMoniker(standaloneSecret);
+
+                            if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
+                                pattern.DetectionMetadata.HasFlag(DetectionMetadata.MediumConfidence) ||
+                                pattern.DetectionMetadata.HasFlag(DetectionMetadata.HighConfidence))
+                            {
+                                continue;
+                            }
+
+                            missingConfidence.Add(moniker);
+
+                            // We only require a single match to identify missing confidence,
+                            // which is expressed at the pattern level.
+                            break;
                         }
-
-                        missingConfidence.Add(moniker);
-
-                        // We only require a single match to identify missing confidence,
-                        // which is expressed at the pattern level.
-                        break;
                     }
                 }
-            }
 
-            missingConfidence.Should().HaveCount(0, because: $"{string.Join(", ", missingConfidence)} are missing an explicit confidence level");
+                missingConfidence.Should().HaveCount(0, because: $"{string.Join(", ", missingConfidence)} are missing an explicit confidence level");
+            }
         }
 
 
         [TestMethod]
         public void WellKnownRegexPatterns_EnsureAllMediumConfidenceOrBetterPatternsDefineSignatures()
         {
-            using var assertionScope = new AssertionScope();
-
-            var rulesets = new[]{
-                WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
-                WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
-            };
-
-            var missingSignatures = new List<string>();
-
-            foreach (IEnumerable<RegexPattern> ruleset in rulesets)
+            for (int i = 0; i < 1000; i++)
             {
-                foreach (RegexPattern pattern in ruleset)
+                using var assertionScope = new AssertionScope();
+
+                var rulesets = new[] {
+                    WellKnownRegexPatterns.UnclassifiedPotentialSecurityKeys,
+                    WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys
+                };
+
+                var missingSignatures = new List<string>();
+
+                foreach (IEnumerable<RegexPattern> ruleset in rulesets)
                 {
-                    foreach (string example in pattern.GenerateTruePositiveExamples())
+                    foreach (RegexPattern pattern in ruleset)
                     {
-                        string standaloneSecret =
-                            CachedDotNetRegex.Instance.Matches(example, 
-                                                               pattern.Pattern, 
-                                                               captureGroup: "refine").First().Value;
-
-                        string moniker = pattern.GetMatchMoniker(standaloneSecret);
-
-                        if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
-                            (pattern.Signatures != null && pattern.Signatures.Any()))
+                        foreach (string example in pattern.GenerateTruePositiveExamples())
                         {
-                            continue;
+                            string standaloneSecret =
+                                CachedDotNetRegex.Instance.Matches(example,
+                                                                   pattern.Pattern,
+                                                                   captureGroup: "refine").First().Value;
+
+                            string moniker = pattern.GetMatchMoniker(standaloneSecret);
+
+                            if (pattern.DetectionMetadata.HasFlag(DetectionMetadata.LowConfidence) ||
+                                (pattern.Signatures != null && pattern.Signatures.Any()))
+                            {
+                                continue;
+                            }
+
+                            missingSignatures.Add(moniker);
+
+                            // We only require a single match to identify missing confidence,
+                            // which is expressed at the pattern level.
+                            break;
                         }
-
-                        missingSignatures.Add(moniker);
-
-                        // We only require a single match to identify missing confidence,
-                        // which is expressed at the pattern level.
-                        break;
                     }
                 }
-            }
 
-            missingSignatures.Should().HaveCount(0, because: $"{string.Join(", ", missingSignatures)} are medium or high confidence patterns that should declare one or more signatures for pre-filtering");
+                missingSignatures.Should().HaveCount(0, because: $"{string.Join(", ", missingSignatures)} are medium or high confidence patterns that should declare one or more signatures for pre-filtering");
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
- FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.
- FNS: Eliminate false negatives resulting from improper use of the `-` character in regexes (where it was interpreted as a range operator not a literal).,
