### PR TITLE
Run tests on .NET 8, fix issues uncovered by that

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -14,7 +14,7 @@
 # 1.13.0 - UNRELEASED
 - BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey(byte[], string)` did not validate signature argument to be be exactly 4 characters long, beginning with a letter, entirely alphanumeric, and either entirely uppercase or entirely lowercase. 
 - BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey` (all overloads)  did not check that the key had the given signature and would return true for any valid key.
-- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key`, when given a backwards-compatible `CommonAnnotatedKey`, also did not check that the key had the given signature.
+- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key`, when given a backwards-compatible `CommonAnnotatedKey`, did not check that the key had the given signature.
 - BUG: `IdentifiableSecrets.(Try)ValidateBase64Key` failed on .NET 8 with `System.NotSupportedException: The specified pattern with RegexOptions.NonBacktracking could result in an automata as large as 'NNNN' nodes, which is larger than the configured limit of '1000'.`
 - PRF: `IdentifiableSecrets.(Try)ValidateBase64Key` is much faster now as it no longer generates nor uses regular expressions.
 

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -15,7 +15,7 @@
 - BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey(byte[], string)` did not validate signature argument to be be exactly 4 characters long, beginning with a letter, entirely alphanumeric, and either entirely uppercase or entirely lowercase. 
 - BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey` (all overloads)  did not check that the key had the given signature and would return true for any valid key.
 - BUG: `IdentifiableSecrets.(Try)ValidateBase64Key`, when given a backwards-compatible `CommonAnnotatedKey`, did not check that the key had the given signature.
-- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key` failed on .NET 8 with `System.NotSupportedException: The specified pattern with RegexOptions.NonBacktracking could result in an automata as large as 'NNNN' nodes, which is larger than the configured limit of '1000'.`
+- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key` failed on .NET 8 with `System.NotSupportedException: The specified pattern with RegexOptions.NonBacktracking could result in an automata as large as 'NNNN' nodes, which is larger than the configured limit of '1000'.` This was due to using a regex with a quantifier that was too large, and fixed by removing the regex entirely.
 - PRF: `IdentifiableSecrets.(Try)ValidateBase64Key` is much faster now as it no longer generates nor uses regular expressions.
 
 # 1.12.0 - 01/06/2025

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,13 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# 1.13.0 - UNRELEASED
+- BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey(byte[], string)` did not validate signature argument to be be exactly 4 characters long, beginning with a letter, entirely alphanumeric, and either entirely uppercase or entirely lowercase. 
+- BUG: `IdentifiableSecrets.TryValidateCommonAnnotatedKey` (all overloads)  did not check that the key had the given signature and would return true for any valid key.
+- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key`, when given a backwards-compatible `CommonAnnotatedKey`, also did not check that the key had the given signature.
+- BUG: `IdentifiableSecrets.(Try)ValidateBase64Key` failed on .NET 8 with `System.NotSupportedException: The specified pattern with RegexOptions.NonBacktracking could result in an automata as large as 'NNNN' nodes, which is larger than the configured limit of '1000'.`
+- PRF: `IdentifiableSecrets.(Try)ValidateBase64Key` is much faster now as it no longer generates nor uses regular expressions.
+
 # 1.12.0 - 01/06/2025
 - BRK: Derived keys and hashed data are no longer supported. The following API are removed:
   - `IdentifiableSecrets.CommonAnnotatedDerivedKeySignature`

--- a/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/CommonAnnotatedKey.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Security.Utilities
                 return false;
             }
 
-            string base64EncodedSignature = key.Substring(76, 4);
+            string base64EncodedSignature = key.Substring(ProviderFixedSignatureOffset, ProviderFixedSignatureLength);
 
             bool longForm = key.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize;
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/Azure64ByteIdentifiableKeys.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/Azure64ByteIdentifiableKeys.cs
@@ -39,7 +39,7 @@ internal sealed class Azure64ByteIdentifiableKeys : RegexPattern
             return null;
         }
 
-        string signature = match.Substring(76, 4);
+        string signature = match.Substring(CommonAnnotatedKey.ProviderFixedSignatureOffset, CommonAnnotatedKey.ProviderFixedSignatureLength);
 
         return signature switch
         {

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -337,9 +337,9 @@ namespace Microsoft.Security.Utilities
                     result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
 
                     string differentSignature = GetRandomSignature();
-                    differentSignature.Should().NotBe(signature, because: "it is random.");
+                    differentSignature.Should().NotBe(signature, because: "it is random");
                     result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, differentSignature);
-                    result.Should().BeFalse(because: $"'{key}' has signature '{signature}', not '{differentSignature}'.");
+                    result.Should().BeFalse(because: $"'{key}' has signature '{signature}', not '{differentSignature}'");
 
                     CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask);
                     cask.Should().NotBeNull(because: $"the '{key}' should be a valid cask");
@@ -473,7 +473,7 @@ namespace Microsoft.Security.Utilities
 
                 string differentSignature = "WXYZ";
                 result = TryValidateCommonAnnotatedKeyHelper(validKey, differentSignature);
-                result.Should().BeFalse(because: $"'{validKey}' has signature '{validSignature}', not '{differentSignature}'.");
+                result.Should().BeFalse(because: $"'{validKey}' has signature '{validSignature}', not '{differentSignature}'");
 
                 result = validKey.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize
                     ? validKey.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize
@@ -1041,7 +1041,7 @@ namespace Microsoft.Security.Utilities
             result.Should().Be(false, because: "validation of standard base64 key with encodeForUrl=true should fail");
 
             result = IdentifiableSecrets.TryValidateBase64Key(secretBase64Url, seed, signature, encodeForUrl: false);
-            result.Should().Be(false, because: "validation of base64url key with econdeForUrl=false should fail");
+            result.Should().Be(false, because: "validation of base64url key with encodeForUrl=false should fail");
         }
 
         [TestMethod]

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -539,7 +539,7 @@ namespace Microsoft.Security.Utilities
             result.Should().BeTrue(because: "a generated key should validate");
 
             result = TryValidateCommonAnnotatedKeyHelper(validKey, base64EncodedSignature: "aBcD");
-            result.Should().BeFalse(because: "although the signature comparison is case-insentitive, the signature argument must have consistent case.");
+            result.Should().BeFalse(because: "although the signature comparison is case-insentitive, the signature argument must have consistent case");
 
             foreach (string signature in new[] { "Z", "YY", "XXX", "WWWWW", "1AAA" })
             {

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableSecretsTests.cs
@@ -15,6 +15,8 @@ using FluentAssertions.Execution;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable SYSLIB0023  // 'RNGCryptoServiceProvider' is obsolete.
+
 namespace Microsoft.Security.Utilities
 {
     [TestClass, ExcludeFromCodeCoverage]
@@ -320,6 +322,11 @@ namespace Microsoft.Security.Utilities
                     bool result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, signature);
                     result.Should().BeTrue(because: $"{key}' should validate using 'TryValidateCommonAnnotatedKey' with its original checksum");
 
+                    string differentSignature = GetRandomSignature();
+                    differentSignature.Should().NotBe(signature, because: "it is random.");
+                    result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, differentSignature);
+                    result.Should().BeFalse(because: $"'{key}' has signature '{signature}', not '{differentSignature}'.");
+
                     CommonAnnotatedKey.TryCreate(key, out CommonAnnotatedKey cask);
                     cask.Should().NotBeNull(because: $"the '{key}' should be a valid cask");
 
@@ -447,8 +454,12 @@ namespace Microsoft.Security.Utilities
                                                                                  new byte[3],
                                                                                  longForm: true);
 
-                bool result = TryValidateCommonAnnotatedKeyHelper(validKey, validSignature, out string failedApi);
-                result.Should().BeTrue(because: $"'{validKey}' should validate using '{failedApi}'");
+                bool result = TryValidateCommonAnnotatedKeyHelper(validKey, validSignature);
+                result.Should().BeTrue(because: $"'{validKey}' should validate.");
+
+                string differentSignature = "WXYZ";
+                result = TryValidateCommonAnnotatedKeyHelper(validKey, differentSignature);
+                result.Should().BeFalse(because: $"'{validKey}' has signature '{validSignature}', not '{differentSignature}'.");
 
                 result = validKey.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize
                     ? validKey.Length == IdentifiableSecrets.LongFormEncodedCommonAnnotatedKeySize
@@ -458,18 +469,21 @@ namespace Microsoft.Security.Utilities
             }
         }
 
-        private bool TryValidateCommonAnnotatedKeyHelper(string key, string base64EncodedSignature, out string failedApi)
+        private bool TryValidateCommonAnnotatedKeyHelper(string key, string base64EncodedSignature)
         {
-            failedApi = "TryValidateCommonAnnotatedKey(string, string)";
-            if (!IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, base64EncodedSignature)) 
-            { 
-                return false; 
-            }
-
-            failedApi = "TryValidateCommonAnnotatedKey(byte[], string)";
             byte[] keyBytes = Convert.FromBase64String(key);
+            bool resultFromString = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key, base64EncodedSignature);
+            bool resultFromBytes = IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, base64EncodedSignature);
+        
+            resultFromBytes.Should().Be(resultFromString, because: 
+                $"""
+                TryValidate(string, string) and TryValidate(byte[], string) should be equivalent,
+                but returned different results for key='{key}', signature='{base64EncodedSignature}':
+                  * TryValidate(string, string) -> {resultFromString}
+                  * TryValidate(byte[], string) -> {resultFromBytes}{Environment.NewLine}
+                """);
 
-            return IdentifiableSecrets.TryValidateCommonAnnotatedKey(keyBytes, base64EncodedSignature);
+            return resultFromString;
         }
 
         [TestMethod]
@@ -507,8 +521,11 @@ namespace Microsoft.Security.Utilities
                                                                              new byte[9],
                                                                              new byte[3]);
 
-            bool result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(validKey, validSignature);
+            bool result = TryValidateCommonAnnotatedKeyHelper(validKey, validSignature);
             result.Should().BeTrue(because: "a generated key should validate");
+
+            result = TryValidateCommonAnnotatedKeyHelper(validKey, base64EncodedSignature: "aBcD");
+            result.Should().BeFalse(because: "although the signature comparison is case-insentitive, the signature argument must have consistent case.");
 
             foreach (string signature in new[] { "Z", "YY", "XXX", "WWWWW", "1AAA" })
             {
@@ -523,7 +540,7 @@ namespace Microsoft.Security.Utilities
 
                     action.Should().Throw<ArgumentException>(because: $"the signature '{signature}' is not valid");
 
-                    result = IdentifiableSecrets.TryValidateCommonAnnotatedKey(key: validKey, base64EncodedSignature: signature);
+                    result = TryValidateCommonAnnotatedKeyHelper(key: validKey, base64EncodedSignature: signature);
                     result.Should().BeFalse(because: $"'{signature}' is not a valid signature argument");
                 }
             }
@@ -988,6 +1005,29 @@ namespace Microsoft.Security.Utilities
                                                                 base64EncodedSignature: "this signature is too long",
                                                                 encodeForUrl));
             }
+        }
+
+        [TestMethod]
+        public void IdentifiableSecrets_TryValidateBase64Key_ChecksAlphabet()
+        {
+            using var scope = new AssertionScope();
+            bool result;
+            ulong seed = 42;
+            string signature = "TEST";
+            string secretBase64Std = "83Tv3p0dtmc/cw7eEVxcC7lh6ZM+MgPG3TESTLBLKt4=";
+            string secretBase64Url = "83Tv3p0dtmc_cw7eEVxcC7lh6ZM-MgPG3TESTLBLKt4=";
+
+            result = IdentifiableSecrets.TryValidateBase64Key(secretBase64Std, seed, signature, encodeForUrl: false);
+            result.Should().Be(true, because: "validation of standard base64 key with encodeForUrl=false should succeed");
+
+            result = IdentifiableSecrets.TryValidateBase64Key(secretBase64Url, seed, signature, encodeForUrl: true);
+            result.Should().Be(true, because: "validation of base64url key with encodeForUrl=true should succeed");
+
+            result = IdentifiableSecrets.TryValidateBase64Key(secretBase64Std, seed, signature, encodeForUrl: true);
+            result.Should().Be(false, because: "validation of standard base64 key with encodeForUrl=true should fail");
+
+            result = IdentifiableSecrets.TryValidateBase64Key(secretBase64Url, seed, signature, encodeForUrl: false);
+            result.Should().Be(false, because: "validation of base64url key with econdeForUrl=false should fail");
         }
 
         [TestMethod]

--- a/src/Tests.Microsoft.Security.Utilities.Core/MarvinTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/MarvinTests.cs
@@ -8,6 +8,8 @@ using System.Text;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable SYSLIB0023  // 'RNGCryptoServiceProvider' is obsolete.
+
 namespace Microsoft.Security.Utilities
 {
     [TestClass, ExcludeFromCodeCoverage]

--- a/src/Tests.Microsoft.Security.Utilities.Core/Tests.Microsoft.Security.Utilities.Core.csproj
+++ b/src/Tests.Microsoft.Security.Utilities.Core/Tests.Microsoft.Security.Utilities.Core.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   


### PR DESCRIPTION
This started with wanting to examine `IdentifiableScan` performance. I profiled its unit test and the profiler told me that it was spending a lot of time in regular expressions and so I probably wanted to use a newer version of .NET. :) This made me realize that the tests were running only on .NET Framework. I enabled them on .NET 8 and when I ran them, I was greeted with `System.NotSupportedException: The specified pattern with RegexOptions.NonBacktracking could result in an automata as large as 'NNNN' nodes, which is larger than the configured limit of '1000'.`

This was due to `ValidateBase64Key` generating a regex with a large quantifier for large input. I fixed this by removing the regex generation and use. Instead, we only check that 1) there is not inconsistent use of base64url or standard base64 with respect to the `encodeForUrl` argument, and 2) the key has the signature provided. The remainder of the work done by the generated regex was redundant to what had already been ascertained by `ValidateChecksum`. In addition to fixing the bug, this improved the performance of the slowest test, `IdentifiableSecrets_GenerateBase64Key_Comprehensive`, by about 8x on .NET Framework.

While looking at this, I further discovered that `ValidateBase64Key`  did not check the signature if given a backwards-compatible `CommonAnnotatedKey`, and that `ValidateCommonAnnotatedKey` didn't check the signature at all. Also, the `byte[]` version of ValidateCommonAnnotatedKey did not validate the signature argument. These bugs are fixed here as well.