### PR TITLE
build: speed up BuildAndTest.cmd

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -1,47 +1,18 @@
 @echo off
-time /T
+setlocal
 
-pushd .\src\security_utilities_rust\
-call cargo clean --release
-call cargo test --release
-if "%ERRORLEVEL%" NEQ "0" (
-  echo "security_utilities_rust testing failed..."
-  exit /b %ERRORLEVEL%
-)
-popd
+time /t
+set RESULT=1
 
-pushd .\src\security_utilities_rust_ffi\
-call cargo clean --release
-call cargo test --release
-if "%ERRORLEVEL%" NEQ "0" (
-  echo "security_utilities_rust_ffi testing failed..."
-  exit /b %ERRORLEVEL%
-)
-popd
+call "%~dp0BuildAndTestRust.cmd" %*
+set RESULT=%ERRORLEVEL%
+if %RESULT% neq 0 goto :exit
 
-pushd .\src\security_utilities_rust_ffi\
-call cargo clean --release
-call cargo build --release --target x86_64-pc-windows-msvc
-if "%ERRORLEVEL%" NEQ "0" (
-  echo "security_utilities_rust_ffi build failed for x86_64-pc-windows-msvc target..."
-  exit /b %ERRORLEVEL%
-)
-call cargo build --release --target i686-pc-windows-msvc
-if "%ERRORLEVEL%" NEQ "0" (
-  echo "security_utilities_rust_ffi build failed for i686-pc-windows-msvc target..."
-  exit /b %ERRORLEVEL%
-)
+call powershell -ExecutionPolicy RemoteSigned -File "%~dp0scripts\BuildAndTest.ps1" %*
+set RESULT=%ERRORLEVEL%
+if %RESULT% neq 0 goto :exit
 
-popd
-
-xcopy /Y .\src\security_utilities_rust_ffi\target\i686-pc-windows-msvc\release\microsoft_security_utilities_core.dll .\refs\win-x86\
-xcopy /Y .\src\security_utilities_rust_ffi\target\i686-pc-windows-msvc\release\microsoft_security_utilities_core.pdb .\refs\win-x86\
-xcopy /Y .\src\security_utilities_rust_ffi\target\x86_64-pc-windows-msvc\release\microsoft_security_utilities_core.dll .\refs\win-x64\
-xcopy /Y .\src\security_utilities_rust_ffi\target\x86_64-pc-windows-msvc\release\microsoft_security_utilities_core.pdb .\refs\win-x64\
-
-call powershell -ExecutionPolicy RemoteSigned -File %~dp0\scripts\BuildAndTest.ps1 %*
-set result=%ERRORLEVEL%
-time /T
+:exit
+time /t
 echo %RESULT%
-
 exit /b %RESULT%

--- a/BuildAndTestRust.cmd
+++ b/BuildAndTestRust.cmd
@@ -1,0 +1,49 @@
+@echo off
+setlocal
+
+set NO_TEST=0
+
+:parse_args
+set ARG=%1
+if /i "%ARG%" == "-NoTest" set NO_TEST=1
+if not "%ARG%" == "" shift & goto :parse_args
+
+set STEP=Building security_utilities_rust_ffi for x64
+echo %STEP%...
+pushd .\src\security_utilities_rust_ffi\
+call cargo build --release --target x86_64-pc-windows-msvc
+if %ERRORLEVEL% neq 0 goto :exit
+popd
+
+set STEP=Building security_utilities_rust_ffi for x86
+echo %STEP%...
+pushd .\src\security_utilities_rust_ffi\
+call cargo build --release --target i686-pc-windows-msvc 
+if %ERRORLEVEL% neq 0 goto :exit
+popd
+
+set STEP=Deploying security_utilities_rust_ffi
+echo %STEP%...
+xcopy /y .\src\security_utilities_rust_ffi\target\x86_64-pc-windows-msvc\release\microsoft_security_utilities_core.dll .\refs\win-x64\
+if %ERRORLEVEL% neq 0 goto :exit
+xcopy /y .\src\security_utilities_rust_ffi\target\x86_64-pc-windows-msvc\release\microsoft_security_utilities_core.pdb .\refs\win-x64\
+if %ERRORLEVEL% neq 0 goto :exit
+xcopy /y .\src\security_utilities_rust_ffi\target\i686-pc-windows-msvc\release\microsoft_security_utilities_core.dll .\refs\win-x86\
+if %ERRORLEVEL% neq 0 goto :exit
+xcopy /y .\src\security_utilities_rust_ffi\target\i686-pc-windows-msvc\release\microsoft_security_utilities_core.pdb .\refs\win-x86\
+if %ERRORLEVEL% neq 0 goto :exit
+
+set STEP=Testing security_utilities_rust
+if %NO_TEST% neq 1 (
+  echo %STEP%...
+  pushd .\src\security_utilities_rust\
+  call cargo test --release 
+  if %ERRORLEVEL% neq 0 goto :exit
+  popd
+)
+
+:exit
+if %ERRORLEVEL% neq 0 (
+  echo ERROR: %STEP% failed.
+)
+exit /b %ERRORLEVEL%

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -51,11 +51,6 @@ function Exit-WithFailureMessage($scriptName, $message) {
     exit 1
 }
 
-If (Test-Path "..\bld") {
-    Write-Information "Deleting old build..."
-    rd /s /q ..\bld
-}
-
 if (-not $NoBuild) {
     Write-Information "Building Microsoft.Security.Utilities.sln (dotnet)..."
     dotnet build $RepoRoot\src\Microsoft.Security.Utilities.sln -c $Configuration -p:Deterministic=true -p:WarningsAsErrors="MSB3277"
@@ -96,22 +91,24 @@ if ($LASTEXITCODE -ne 0) {
     Exit-WithFailureMessage $ScriptName "Build of SecurityUtilitiesPackageReference failed."
 }
 
-Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net451..."
-Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net451\SecurityUtilitiesApiUtilizationExample.exe"
-if ($LASTEXITCODE -ne 0) {
-    Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
-}
+if (-not $NoTest) {
+    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net451..."
+    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net451\SecurityUtilitiesApiUtilizationExample.exe"
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+    }
 
-Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net462..."
-Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net462\SecurityUtilitiesApiUtilizationExample.exe"
-if ($LASTEXITCODE -ne 0) {
-    Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
-}
+    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net462..."
+    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net462\SecurityUtilitiesApiUtilizationExample.exe"
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+    }
 
-Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net6.0..."
-Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net6.0\SecurityUtilitiesApiUtilizationExample.exe"
-if ($LASTEXITCODE -ne 0) {
-    Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net6.0..."
+    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net6.0\SecurityUtilitiesApiUtilizationExample.exe"
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+    }
 }
 
 Write-Information "$ScriptName SUCCEEDED."


### PR DESCRIPTION
`BuildAndTest` was terribly slow and basically unusable in any inner loop. The main culprit was that `cargo clean` was done on every invocation. This causes the rust world to be rebuilt every single time, and that is quite slow. There were some other issues that are also fixed here.

Changes:
* Remove all `cargo clean` calls. Either use `git clean` or run `cargo clean` yourself if you want to rebuild. This is consistent with the C# behavior of `BuildAndTest`.
* Stop doing `cargo test` on the `ffi` directory as this builds stuff again unnecessarily but runs no additional tests.
* Extract a separate BuildAndTestRust.cmd script to allow iteration on rust changes without running C# build and test steps.
* Respect `-NoTest` argument for rust.
* Clean up some build error handling and logging output.
* Remove dead `rd /s /q` code. If you had a `<repo>\..\bld`, which you usually don't, it would fail because this is cmd not powershell syntax. Furthermore, blowing away `bld` n every invocation runs counter to the goal here of speeding things up for iteration, so it is better to delete this thing that never did anything than to fix it.