### PR TITLE
ci: fix build break due to deprecated v3 artifact upload

### DIFF
--- a/.github/workflows/test-marvin-nodejs.yml
+++ b/.github/workflows/test-marvin-nodejs.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run tests
         run: npm test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Fixed by using v4.