### PR TITLE
Fix incorrect signatures preventing rust scanner from being used for two patterns

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -361,7 +361,7 @@
     "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
     "Signatures": [

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -391,7 +391,7 @@
     "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
     "Signatures": [

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,10 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- PRF: `IdentifiableScan` did not use high-performance rust scanner for `SEC101/178: Microsoft Azure IoT identifiable key` and `SEC101/200: Microsoft common annotated security key (HIS v2)`.
+- BUG: `SecretMasker` considered non-alphanumeric delimiter preceding secret to be part of the match for `SEC101/200: Microsoft common annotated security key (HIS v2)`. This yielded an incorrect correlation ID for the detection.
+
 # 1.13.0 - 02/05/2025
 - FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.
 - FNS: Eliminate false negatives resulting from improper use of the `-` character in regexes (where it was interpreted as a range operator not a literal).,

--- a/docs/ReleaseHistory_Rust.md
+++ b/docs/ReleaseHistory_Rust.md
@@ -13,10 +13,14 @@ This document contains release notes pertaining to the Rust crates.
 - FNS => False negative reduction in static analysis.
 
 # UNRELEASED
+- FNS: Add detection of derived and hashed HIS v2 keys for `SEC101/200: Microsoft common annotated security key (HIS v2)`.
+
+# 1.5.4 - 11/19/2024
+- DEP: Removed dependency of the `base-62` crate since it depended on the `failure` crate which has a known [vulnerability](https://github.com/advisories/GHSA-jq66-xh47-j9f3).
 - NEW: Introduce `marvin::{compute_hash_slice, compute_hash32_slice}` to compute marvin checksums directly from slices. `marvin::{compute_hash, compute_hash32}` also rely on the new, faster implementation.
 
 # 1.5.3 - 07/26/2024
-- DEP: `System.Text.Json` updated to `v8.0.4` to resolve Depandabot alert.
+- DEP: `System.Text.Json` updated to `v8.0.4` to resolve Dependabot alert.
 - NEW: Introduces the `ScanEngine` struct, which allows simplified usage in concurrent scenarios---a single `ScanEngine` instance, along with per-thread `ScanState` instances, suffice without the need for additional synchronization. The existing `Scan` struct is operationally unchanged for users.
 - BRK: `Send` and `Sync` bounds have been added for `ScanDefinition` validators. This allows `ScanEngine` to be `Send + Sync`.
 

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
@@ -87,10 +87,10 @@ public class IdentifiableScan : ISecretMasker, IDisposable
             "+AEh",
             "+ARm",
             "+ACR",
-            "+AIoT",
+            "AIoT",
             "APIM",
             "AZEG",
-            "JQQJ",
+            "JQQJ9",
         });
 
     public IdentifiableScan(IEnumerable<RegexPattern> regexPatterns, bool generateCorrelatingIds, IRegexEngine regexEngine = null)

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/200";
             Name = nameof(CommonAnnotatedSecurityKey);
             DetectionMetadata = DetectionMetadata.Identifiable;
-            Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
+            Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?P<refine>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
             Signatures = "JQQJ9".ToSet();
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/565";
             Name = nameof(SecretScanningSampleToken);
             DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
-            Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{{5}}){WellKnownRegexPatterns.SuffixBase62}";
+            Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?P<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{{5}}){WellKnownRegexPatterns.SuffixBase62}";
             Signatures = "ab85".ToSet();
         }
 

--- a/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
+++ b/src/security_utilities_rust/src/microsoft_security_utilities_core/identifiable_scans.rs
@@ -739,7 +739,7 @@ impl ScanOptions {
         let match_bytes = |data: &[u8]| -> usize {
             /*
              * Checks are equivalent to this regex:
-             * [A-Za-z0-9]{52}JQQJ99[A-Za-z0-9][A-L][A-Za-z0-9]{16}[A-Za-z][A-Za-z0-9]{7}([A-Za-z0-9]{2}==)?
+             * [A-Za-z0-9]{52}JQQJ9(9|D|H)[A-Za-z0-9][A-L][A-Za-z0-9]{16}[A-Za-z][A-Za-z0-9]{7}([A-Za-z0-9]{2}==)?
              */
             if data.len() < HIS2_UTF8_SHORT_LEN {
                 return 0;
@@ -751,7 +751,11 @@ impl ScanOptions {
                 }
             }
 
-            if &data[52..58] != b"JQQJ99" {
+            if &data[52..57] != b"JQQJ9" {
+                return 0;
+            }
+
+            if data[57] != b'9' && data[57] != b'D' && data[57] != b'H' {
                 return 0;
             }
 


### PR DESCRIPTION
`IdentifiableScan` falls back to the slower `SecretMasker` for patterns that aren't detected by rust. Determining if rust can detect a pattern is controlled by a hard-coded list of signatures. In two cases, HIS v2 and Azure IOT, the values in the hard-coded list did not match the signatures of their `RegexPattern`s. This results in using the backup slower masker for these two patterns.

Fixing this causes tests to fail when rust fails to match `JQQJ9D` (derived) and `JQQJ9H` (hashed) patterns. This draft adds support for these to rust, but these formats never got off the ground and should probably be removed throughout instead.

Fixing this also reveals that the C# masker was including the non-alphanumeric character preceding an HIS v2 secret in its match. Once `IdentifiableScan` started to use rust for HIS v2 matching, tests failed because the C3IDs didn't match. This is fixed as well by using "refine" as the capture name instead of "secret".

Also fix missing rust release notes for previous release.