### PR TITLE
feat: add SEC101/055.Pkcs12CertificatePrivateKeyBundle

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -12,13 +12,12 @@
 - FNS => False negative reduction in static analysis.
 
 # UNRELEASED
-- RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify data.
-- RUL: Add `DAT101/002.IPv4`.
-- RUL: Add `DAT101/003.IPv6`.
-- RUL: Add `DAT101/004.Integer`.
-- RUL: Add `DAT101/005.Float`.
-- RUL: Add `DAT101/006.Double`.
-- RUL: Add `DAT101/007.Pkcs12Certificate`.
+- RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.
+- RUL: Add `DAT101/002.IPv4` non-sensitive data classification.
+- RUL: Add `DAT101/003.IPv6` non-sensitive data classification.
+- RUL: Add `DAT101/004.Integer` non-sensitive data classification.
+- RUL: Add `DAT101/005.Float` non-sensitive data classification.
+- RUL: Add `SEC101/055.Pkcs12CertificatePrivateKeyBundle` detection. This is currently solely regex based and does not yet guarantee fully-formed PKCS #12.
 
 # 1.13.0 - 02/05/2025
 - FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -12,11 +12,13 @@
 - FNS => False negative reduction in static analysis.
 
 # UNRELEASED
-- RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.
-- RUL: Add `DAT101/002.IPv4` non-sensitive data classification.
-- RUL: Add `DAT101/003.IPv6` non-sensitive data classification.
-- RUL: Add `DAT101/004.Integer` non-sensitive data classification.
-- RUL: Add `DAT101/005.Float` non-sensitive data classification.
+- RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify data.
+- RUL: Add `DAT101/002.IPv4`.
+- RUL: Add `DAT101/003.IPv6`.
+- RUL: Add `DAT101/004.Integer`.
+- RUL: Add `DAT101/005.Float`.
+- RUL: Add `DAT101/006.Double`.
+- RUL: Add `DAT101/007.Pkcs12Certificate`.
 
 # 1.13.0 - 02/05/2025
 - FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.

--- a/src/Microsoft.Security.Utilities.Core/DataClassification/DAT101_006_Pkcs12Certificate.cs
+++ b/src/Microsoft.Security.Utilities.Core/DataClassification/DAT101_006_Pkcs12Certificate.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Security.Utilities
+{
+    public class Pkcs12Certificate : RegexPattern
+    {
+        public Pkcs12Certificate()
+        {
+            Id = "DAT101/006";
+            Name = nameof(Pkcs12Certificate);
+            Pattern = @"MI[I-L][0-9a-zA-Z\/+]{2}[AQgw]IBAzCC";
+        }
+
+        public override IEnumerable<string> GenerateTruePositiveExamples()
+        {
+#if NET6_0_OR_GREATER
+            foreach (string? password in new string?[] { Guid.NewGuid().ToString(), null })
+            {
+                foreach (int keyLength in new int[] { 1024, 2048, 4096 })
+                {
+                    yield return GenerateTestPkcs12(keyLength, password);
+                }
+            }
+
+            // Example showing regex will matchh in the middle of the string (i.e. unanchored).
+            yield return $"some padding data {GenerateTestPkcs12(2048, null)} more padding data";
+
+            // Example showing incomplete data will match.
+            yield return GenerateTestPkcs12(2048, null).Substring(0, 20);
+#else
+            return [];
+#endif
+        }
+
+#if NET6_0_OR_GREATER
+        private static string GenerateTestPkcs12(int keyLength, string? password)
+        {
+            using var rsa = RSA.Create(keyLength);
+            var certRequest = new CertificateRequest("cn=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            using var cert = certRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
+            var pkcs12 = cert.Export(X509ContentType.Pkcs12, password);
+            return Convert.ToBase64String(pkcs12);
+        }
+#else
+        private static string GenerateTestPkcs12(int keyLength, string? password)
+        {
+            throw new NotImplementedException("'GenerateTestPkcs12' is not yet implemented for TargetFrameworks lower than net451.");
+        }
+#endif
+
+    }
+}

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/055";
             Name = nameof(Pkcs12CertificatePrivateKeyBundle);
             Pattern = @"MI[I-L][0-9a-zA-Z\/+]{2}[AQgw]IBAzCC";
+            Signatures = new[] { "IBAzCC" }.ToSet();
         }
 
         public override IEnumerable<string> GenerateTruePositiveExamples()

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
@@ -5,14 +5,16 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
+#nullable enable
+
 namespace Microsoft.Security.Utilities
 {
-    public class Pkcs12Certificate : RegexPattern
+    public class Pkcs12CertificatePrivateKeyBundle : RegexPattern
     {
-        public Pkcs12Certificate()
+        public Pkcs12CertificatePrivateKeyBundle()
         {
-            Id = "DAT101/006";
-            Name = nameof(Pkcs12Certificate);
+            Id = "SEC101/055";
+            Name = nameof(Pkcs12CertificatePrivateKeyBundle);
             Pattern = @"MI[I-L][0-9a-zA-Z\/+]{2}[AQgw]IBAzCC";
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Security.Utilities
         {
             Id = "SEC101/055";
             Name = nameof(Pkcs12CertificatePrivateKeyBundle);
+            DetectionMetadata = DetectionMetadata.MediumConfidence;
+
             Pattern = @"MI[I-L][0-9a-zA-Z\/+]{2}[AQgw]IBAzCC";
             Signatures = new[] { "IBAzCC" }.ToSet();
         }

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -57,7 +57,8 @@ public static class WellKnownRegexPatterns
         new Unclassified32ByteBase64String(),
         new Unclassified64ByteBase64String(),
         new AadClientAppLegacyCredentials34(),      // SEC101/101
-        new Unclassified16ByteHexadecimalString(),         
+        new Pkcs12CertificatePrivateKeyBundle(),
+        new Unclassified16ByteHexadecimalString(),
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceMicrosoftSecurityModels { get; } = new RegexPattern[]
@@ -99,7 +100,6 @@ public static class WellKnownRegexPatterns
         new Float(),
         new Integer(),
         new GuidValue(),
-        new Pkcs12Certificate(),
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceThirdPartySecurityModels { get; } = new List<RegexPattern>

--- a/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
+++ b/src/Microsoft.Security.Utilities.Core/WellKnownRegexPatterns.cs
@@ -99,6 +99,7 @@ public static class WellKnownRegexPatterns
         new Float(),
         new Integer(),
         new GuidValue(),
+        new Pkcs12Certificate(),
     };
 
     public static IEnumerable<RegexPattern> HighConfidenceThirdPartySecurityModels { get; } = new List<RegexPattern>


### PR DESCRIPTION
- RUL: Add `SEC101/055.Pkcs12CertificatePrivateKeyBundle` detection. This is currently solely regex based and does not yet guarantee fully-formed PKCS #12.

#137 covers adding net451 test coverage. Other Target Frameworks are tested with 100% coverage.