### PR TITLE
Drop net451 and net6.0 support

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -17,6 +17,8 @@
 - RUL: Add `DAT101/003.IPv6` non-sensitive data classification.
 - RUL: Add `DAT101/004.Integer` non-sensitive data classification.
 - RUL: Add `DAT101/005.Float` non-sensitive data classification.
+- BRK: .NET 6.0 and 7.0 are no longer supported as they have reached end-of-life. Use a [supported version version of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
+- BRK: .NET Framework 4.5.1 through 4.6.0 are no longer supported. Use a version of .NET Framework version that supports [.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0): NET 4.6.1 or greater with .NET 4.7.2 or greater strongly recommended. Note that there are no supported versions of Windows that have a version of .NET Framework that would be affected by this change at runtime, but build changes may be required.
 
 # 1.13.0 - 02/05/2025
 - FNS: Eliminate false negatives resulting from incorrectly specifying `=` as a delimiting character in the core 'identifiable' rules. This broke simple patterns such as `myKey=an_actual_key`.

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -74,7 +74,7 @@ if (-not $NoTest) {
 }
 
 Write-Information "Exporting rules data.."
-Invoke-Expression ("$RepoRoot\bld\bin\AnyCPU_Release\Microsoft.Security.Utilities.Cli\net6.0\Microsoft.Security.Utilities.Cli.exe export --output $RepoRoot\GeneratedRegexPatterns\")
+Invoke-Expression ("$RepoRoot\bld\bin\AnyCPU_Release\Microsoft.Security.Utilities.Cli\net8.0\Microsoft.Security.Utilities.Cli.exe export --output $RepoRoot\GeneratedRegexPatterns\")
 if ($LASTEXITCODE -ne 0) {
     Exit-WithFailureMessage $ScriptName "Rules export failed."
 }
@@ -92,22 +92,12 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 if (-not $NoTest) {
-    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net451..."
-    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net451\SecurityUtilitiesApiUtilizationExample.exe"
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
-    }
-
-    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net462..."
-    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net462\SecurityUtilitiesApiUtilizationExample.exe"
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
-    }
-
-    Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on net6.0..."
-    Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\net6.0\SecurityUtilitiesApiUtilizationExample.exe"
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+    foreach ($fx in "net8.0", "net461") {
+        Write-Information "Running API examples using compiled Microsoft.Security.Utilities.Core package on $fx..."
+        Invoke-Expression "$RepoRoot\src\SecurityUtilitiesPackageReference\SecurityUtilitiesApiUtilizationExample\bin\$Configuration\$fx\SecurityUtilitiesApiUtilizationExample.exe"
+        if ($LASTEXITCODE -ne 0) {
+            Exit-WithFailureMessage $ScriptName "Microsoft.Security.Utilities.Core API example execution failed."
+        }
     }
 }
 

--- a/src/Microsoft.Security.Utilities.Cli/Microsoft.Security.Utilities.Cli.csproj
+++ b/src/Microsoft.Security.Utilities.Cli/Microsoft.Security.Utilities.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
+++ b/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
@@ -2,13 +2,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>net451;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Microsoft.Security.Utilities.Core</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" $(TargetFramework) != 'net6.0'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   

--- a/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/SecurityUtilitiesApiUtilizationExample.csproj
+++ b/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/SecurityUtilitiesApiUtilizationExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFrameworks>net451;net462;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net8.0;net461</TargetFrameworks>
 	  <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 


### PR DESCRIPTION
This change is split off from #132 to allow other work that relies on reduced framework support to happen in parallel to closing on #132. Also, it really should have been its own PR anyway. :)