### PR TITLE
Validate and standardize named captures and optimize cached regex lookup

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -328,7 +328,7 @@
     "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
-    "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
+    "Pattern": "(?:^|[^0-9a-f\\-])(?<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
     "Id": "SEC101/110",
     "Name": "AzureDatabricksPat",
     "Signatures": [
@@ -361,7 +361,7 @@
     "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
     "Signatures": [

--- a/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
+    "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
     "Signatures": [

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -1,6 +1,6 @@
 [
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
     "Signatures": [
@@ -335,7 +335,7 @@
     "DetectionMetadata": "HighEntropy, EmbeddedChecksum"
   },
   {
-    "Pattern": "(?i)\\.documents\\.azure\\.com.+(?:^|[^0-9a-z\\/+])(?P<refine>[0-9a-z\\/+]{86}==)(?:[^=]|$)",
+    "Pattern": "(?i)\\.documents\\.azure\\.com.+(?:^|[^0-9a-z\\/+])(?<refine>[0-9a-z\\/+]{86}==)(?:[^=]|$)",
     "Id": "SEC101/104",
     "Name": "AzureCosmosDBLegacyCredentials",
     "Signatures": null,
@@ -349,7 +349,7 @@
     "DetectionMetadata": "HighEntropy"
   },
   {
-    "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
+    "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
     "Signatures": [
@@ -358,7 +358,7 @@
     "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence"
   },
   {
-    "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
+    "Pattern": "(?:^|[^0-9a-f\\-])(?<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
     "Id": "SEC101/110",
     "Name": "AzureDatabricksPat",
     "Signatures": [
@@ -391,7 +391,7 @@
     "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence"
   },
   {
-    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
+    "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
     "Signatures": [

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,6 +11,12 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
+# UNRELEASED
+- BRK: Regular expression syntax has been standardized in JSON to conform to how the overwhelming majority of patterns were already defined.
+  - `refine` is used now used throughout as the name of the capture group used to isolate an actual find from the full expression that also matches delimiting characters. `secret` was previously used in some instances.
+  - `?<name>` is now used throughout for named captures. '?P<name>' was previously used in some instances. This may require replacing '?<' with '?P<' if using a regex engine that only accepts the '?P<name>' syntax.
+- BRK: `CachedDotNetRegexEngine`will no longer accept `(?P<name>)` syntax. This is only relevant if it is used with patterns other than those distributed with this library.
+- BUG: `SEC101/200.CommonAnnotatedSecurityKey` considered non-alphanumeric delimiter preceding secret to be part of the match.
 # 1.14.0 - 02/25/2025
 - RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.
 - RUL: Add `DAT101/002.IPv4` non-sensitive data classification.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -15,8 +15,15 @@
 - BRK: Regular expression syntax has been standardized in JSON to conform to how the overwhelming majority of patterns were already defined.
   - `refine` is used now used throughout as the name of the capture group used to isolate an actual find from the full expression that also matches delimiting characters. `secret` was previously used in some instances.
   - `?<name>` is now used throughout for named captures. '?P<name>' was previously used in some instances. This may require replacing '?<' with '?P<' if using a regex engine that only accepts the '?P<name>' syntax.
+  - Impacted rules:
+      - `SEC101/104.AzureCosmosDBLegacyCredentials`
+      - `SEC101/105.AzureMessagingLegacyCredentials`
+      - `SEC101/110.AzureDatabricksPat`
+      - `SEC101/200.CommonAnnotatedSecurityKey`
+      - `SEC101/565.SecretScanningSampleToken`
 - BRK: `CachedDotNetRegexEngine`will no longer accept `(?P<name>)` syntax. This is only relevant if it is used with patterns other than those distributed with this library.
-- BUG: `SEC101/200.CommonAnnotatedSecurityKey` considered non-alphanumeric delimiter preceding secret to be part of the match.
+- BUG: `SEC101/200.CommonAnnotatedSecurityKey` and `SEC101/565.SecretScanningSampleToken` considered non-alphanumeric delimiter preceding secret to be part of the match.
+
 # 1.14.0 - 02/25/2025
 - RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.
 - RUL: Add `DAT101/002.IPv4` non-sensitive data classification.

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_104_AzureCosmosDBLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_104_AzureCosmosDBLegacyCredentials.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/104";
             Name = nameof(AzureCosmosDBLegacyCredentials);
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat;
-            Pattern = "(?i)\\.documents\\.azure\\.com.+(?:^|[^0-9a-z\\/+])(?P<refine>[0-9a-z\\/+]{86}==)(?:[^=]|$)";
+            Pattern = "(?i)\\.documents\\.azure\\.com.+(?:^|[^0-9a-z\\/+])(?<refine>[0-9a-z\\/+]{86}==)(?:[^=]|$)";
         }
 
         public override Tuple<string, string> GetMatchIdAndName(string match)

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/105";
             Name = nameof(AzureMessageLegacyCredentials);         
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.MediumConfidence;
-            Pattern = "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)";
+            Pattern = "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)";
             Signatures = new HashSet<string>(new[] { ".servicebus" });
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_110.AzureDatabricksPat.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_110.AzureDatabricksPat.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/110";
             Name = nameof(AzureDatabricksPat);
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
-            Pattern = $"(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{{32,34}})(?:[^0-9a-f\\-]|$)";
+            Pattern = $"(?:^|[^0-9a-f\\-])(?<refine>dapi[0-9a-f\\-]{{32,34}})(?:[^0-9a-f\\-]|$)";
             Signatures = new HashSet<string>(new[] { "dapi" });
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/200";
             Name = nameof(CommonAnnotatedSecurityKey);
             DetectionMetadata = DetectionMetadata.Identifiable;
-            Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
+            Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?<refine>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
             Signatures = "JQQJ9".ToSet();
         }
 

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_565_SecretScanningSampleToken.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Security.Utilities
             Id = "SEC101/565";
             Name = nameof(SecretScanningSampleToken);
             DetectionMetadata = DetectionMetadata.FixedSignature | DetectionMetadata.HighEntropy | DetectionMetadata.HighConfidence;
-            Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?P<secret>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{{5}}){WellKnownRegexPatterns.SuffixBase62}";
+            Pattern = @$"{WellKnownRegexPatterns.PrefixBase62}(?<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{{5}}){WellKnownRegexPatterns.SuffixBase62}";
             Signatures = "ab85".ToSet();
         }
 

--- a/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
+++ b/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
@@ -347,15 +347,5 @@ public class RegexPattern
     /// provide regex processing.</remarks>
     public DetectionMetadata DetectionMetadata { get; protected set; }
 
-    internal static string NormalizeGroupsPattern(string pattern)
-    {
-        if (pattern.IndexOf("?P<") != -1)
-        {
-            return pattern.Replace("?P<", "?<");
-        }
-
-        return pattern;
-    }
-
     public bool ShouldSerializeRotationPeriod() => false;
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
@@ -48,7 +48,7 @@ namespace Tests.Microsoft.Security.Utilities.Core
         [TestMethod]
         public void IdentifiableScan_IdentifiableKeys()
         {
-            int iterations = 1000;
+            int iterations = 1;
 
             using var assertionScope = new AssertionScope();
 


### PR DESCRIPTION
- Patterns must have at most one named capture and it must be named 'refine'. Enforce this in a unit test and fix the resulting issues.
- Standardize on `?<refine>` over `?P<refine>` syntax. This is the standard of the vast majority of patterns and is supported by both RE2 and .NET. Engines that require 'P' such as Python would already have had to add it to most of the patterns.
- Remove capture group normalization on GetOrCreateRegex. This is unnecessary after this standardization.
- Use a value tuple to eliminate allocation on regex lookup.
- Prevent closure allocation by using the argument passed to GetOrAdd callback instead of retrieving it from closure.
- Remove explicit static constructor so that CachedDotNetRegex is emitted with `beforefieldinit` flag, which permits better native code gen that no longer has to ensure the precise timing of static initialization.
- Reduce iterations of IdentifiableScan_IdentifiableKeys test to 1. The value of 1000 was meant for local debugging only.