### PR TITLE
Remove incorrect signatures from SEC101/061.LooseOAuth2BearerToken

### DIFF
--- a/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
@@ -3,10 +3,7 @@
     "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
-    "Signatures": [
-      "sig=",
-      "ret="
-    ],
+    "Signatures": null,
     "DetectionMetadata": "LowConfidence"
   },
   {

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -34,10 +34,7 @@
     "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
-    "Signatures": [
-      "sig=",
-      "ret="
-    ],
+    "Signatures": null,
     "DetectionMetadata": "LowConfidence"
   },
   {

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -23,7 +23,7 @@
       - `SEC101/565.SecretScanningSampleToken`
 - BRK: `CachedDotNetRegexEngine`will no longer accept `(?P<name>)` syntax. This is only relevant if it is used with patterns other than those distributed with this library.
 - BUG: `SEC101/200.CommonAnnotatedSecurityKey` and `SEC101/565.SecretScanningSampleToken` considered non-alphanumeric delimiter preceding secret to be part of the match.
-- BUG  `SEC101/061.LooseOAuth2BearerToken` had incorrect signatures, causing no matches to be found unless the input happened to also contain `sig=` or `ret=`
+- BUG  `SEC101/061.LooseOAuth2BearerToken` had incorrect signatures, causing no matches to be found unless the input happened to also contain `sig=` or `ret=`.
 
 # 1.14.0 - 02/25/2025
 - RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -23,6 +23,7 @@
       - `SEC101/565.SecretScanningSampleToken`
 - BRK: `CachedDotNetRegexEngine`will no longer accept `(?P<name>)` syntax. This is only relevant if it is used with patterns other than those distributed with this library.
 - BUG: `SEC101/200.CommonAnnotatedSecurityKey` and `SEC101/565.SecretScanningSampleToken` considered non-alphanumeric delimiter preceding secret to be part of the match.
+- BUG  `SEC101/061.LooseOAuth2BearerToken` had incorrect signatures, causing no matches to be found unless the input happened to also contain `sig=` or `ret=`
 
 # 1.14.0 - 02/25/2025
 - RUL: Add `DAT101/001.GuidValue` detection as part of a new DAT101 detection series which helps classify non-sensitive data.

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_061_LooseOAuth2BearerToken.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_061_LooseOAuth2BearerToken.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Security.Utilities
 
             // https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
             Pattern = @$"(?i)authorization:(\s|%20)bearer(\s|%20)(?<refine>[0-9a-z][{WellKnownRegexPatterns.UrlUnreserved}+\/=]*)([^{WellKnownRegexPatterns.UrlUnreserved}+/=]|$)";
-            Signatures = new HashSet<string>(new[] { "sig=", "ret=" });
         }
 
         public override IEnumerable<string> GenerateTruePositiveExamples()


### PR DESCRIPTION
Also re-enable the test that would have caught this but was disabled against #95. Instead of disabling the test wholesale, add a way to tolerate multiple findings for these rules, still linking to #95 as the reason.