### PR TITLE
1.15.0 Release

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -11,7 +11,7 @@
 - FPS => False positive reduction in static analysis.
 - FNS => False negative reduction in static analysis.
 
-# UNRELEASED
+# 1.15.0 - 03/03/2025
 - BRK: Regular expression syntax has been standardized in JSON to conform to how the overwhelming majority of patterns were already defined.
   - `refine` is used now used throughout as the name of the capture group used to isolate an actual find from the full expression that also matches delimiting characters. `secret` was previously used in some instances.
   - `?<name>` is now used throughout for named captures. '?P<name>' was previously used in some instances. This may require replacing '?<' with '?P<' if using a regex engine that only accepts the '?P<name>' syntax.

--- a/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/SecretMaskerTests.cs
@@ -17,13 +17,6 @@ namespace Microsoft.Security.Utilities;
 public class SecretMaskerTests
 {
     [TestMethod]
-    public void SecretMasker_Version()
-    {
-        Version version = SecretMasker.Version;
-        version.ToString().Should().Be("1.14.0");
-    }
-
-    [TestMethod]
     public void SecretMasker_PreciselyClassifiedSecurityKeys_Detections()
     {
         ValidateSecurityModelsDetections(WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
# 1.15.0 - 03/03/2025
- BRK: Regular expression syntax has been standardized in JSON to conform to how the overwhelming majority of patterns were already defined.
  - `refine` is used now used throughout as the name of the capture group used to isolate an actual find from the full expression that also matches delimiting characters. `secret` was previously used in some instances.
  - `?<name>` is now used throughout for named captures. '?P<name>' was previously used in some instances. This may require replacing '?<' with '?P<' if using a regex engine that only accepts the '?P<name>' syntax.
  - Impacted rules:
      - `SEC101/104.AzureCosmosDBLegacyCredentials`
      - `SEC101/105.AzureMessagingLegacyCredentials`
      - `SEC101/110.AzureDatabricksPat`
      - `SEC101/200.CommonAnnotatedSecurityKey`
      - `SEC101/565.SecretScanningSampleToken`
- BRK: `CachedDotNetRegexEngine`will no longer accept `(?P<name>)` syntax. This is only relevant if it is used with patterns other than those distributed with this library.
- BRK: `IdentifiableSecrets.ComputeDerivedCommonAnnotatedKey` now exclusively throws `System.ArgumentException` for invalid key inputs (no longer raising `System.FormatException: The input is not a valid Base-46 string` for invalid data).
- BUG: `SEC101/200.CommonAnnotatedSecurityKey` and `SEC101/565.SecretScanningSampleToken` considered non-alphanumeric delimiter preceding secret to be part of the match.
- BUG  `SEC101/061.LooseOAuth2BearerToken` had incorrect signatures, causing no matches to be found unless the input happened to also contain `sig=` or `ret=`.
- BUG: Resolve `System.FormatException: The input is not a valid Base-46 string` errors calling `IdentifiableSecrets.ValidateChecksum` with invalid base64. The API now returns `false` in this case.
- BUG: Resolve 'System.NullReferenceException` on calling `RegexPattern.GetMatchMoniker` when its internal call to `GetMatchIdAndName` return null. A null return from `GetMatchIdAndName` is an expected value that indicates post-processing has determined there is no actual match.
- BUG: Resolve `System.FormatException: The input is not a valid Base-46 string` errors calling `SEC101/102.AdoPat.GetMatchIdAndName` with invalid base64. The API now returns null in this case (the standard behavior when post-processing does not detect a match).
 
*NOTE*: this change eliminates the no-value test of the hard-coded version in unit tests that is easy to forget to update.