### PR TITLE
Make ordering of regex properties deterministic.

### DIFF
--- a/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/HighConfidenceSecurityModels.json
@@ -1,17 +1,17 @@
 [
   {
-    "DetectionMetadata": "Identifiable",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Signatures": [
       "JQQJ"
     ]
   },
   {
-    "DetectionMetadata": "Identifiable",
     "Id": "SEC101/156",
     "Name": "AadClientAppIdentifiableCredentials",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/])(?P<refine>[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{3}(7|8)Q~[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{31,34})([^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/]|$)",
     "Signatures": [
       "8Q~",
@@ -19,289 +19,180 @@
     ]
   },
   {
-    "ChecksumSeeds": [
-      5077085528363970608,
-      5575864757416767536,
-      6014965721085063216
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/158",
-    "KeyLength": 40,
     "Name": "AzureFunctionIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]|$)",
     "Signatures": [
       "AzFu"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5869709231681187888
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/166",
-    "KeyLength": 39,
     "Name": "AzureSearchIdentifiableQueryKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzSe"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5783013817603469360
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/167",
-    "KeyLength": 39,
     "Name": "AzureSearchIdentifiableAdminKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzSe"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/173",
-    "KeyLength": 32,
     "Name": "AzureRelayIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ARm"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/172",
-    "KeyLength": 32,
     "Name": "AzureEventHubIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+AEh"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/171",
-    "KeyLength": 32,
     "Name": "AzureServiceBusIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ASb"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5291540757367369776
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/178",
-    "KeyLength": 32,
     "Name": "AzureIotHubIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928475562238095408
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/180",
-    "KeyLength": 32,
     "Name": "AzureIotDeviceIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4931568359632875568
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/179",
-    "KeyLength": 32,
     "Name": "AzureIotDeviceProvisioningIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928457935994778672
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/152",
-    "KeyLength": 64,
     "Name": "AzureStorageAccountIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ASt"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5003045579370016816,
-      5575864757095706672,
-      5575864757096230960,
-      5937278606306848816,
-      6014965502159106096,
-      6014965720764330032,
-      6014965720764854320
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/160",
-    "KeyLength": 64,
     "Name": "AzureCosmosDBIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "ACDb"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4711400055309086768
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/163",
-    "KeyLength": 64,
     "Name": "AzureBatchIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ABa"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4858365246511342384
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/170",
-    "KeyLength": 64,
     "Name": "AzureMLWebServiceClassicIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+AMC"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6081388236577714224
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/181",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableDirectManagementKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5291540757367369776
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/182",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableSubscriptionKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5143520228578766896
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/183",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableGatewayKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5145771916421312560
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/184",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableRepositoryKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4711718922539446320
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/154",
-    "KeyLength": 32,
     "Name": "AzureCacheForRedisIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzCa"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4702692889634567216
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/176",
-    "KeyLength": 39,
     "Name": "AzureContainerRegistryIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ACR"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/031",
     "Name": "NuGetApiKey",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(?i)(^|[^a-z0-9])(?P<refine>oy2[a-z2-7]{43})([^a-z0-9]|$)",
     "Signatures": [
       "oy2",
@@ -309,41 +200,36 @@
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, HighConfidence",
     "Id": "SEC101/110",
     "Name": "AzureDatabricksPat",
+    "DetectionMetadata": "HighEntropy, HighConfidence",
     "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
     "Signatures": [
       "dapi"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928457935994778672
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/199",
-    "KeyLength": 32,
     "Name": "AzureEventGridIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AZEG"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/050",
     "Name": "NpmAuthorKey",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>npm_[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{36})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Signatures": [
       "npm_"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Signatures": [
       "ab85"

--- a/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/LowConfidenceSecurityModels.json
@@ -1,36 +1,36 @@
 [
   {
-    "DetectionMetadata": "LowConfidence",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
+    "DetectionMetadata": "LowConfidence",
     "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?P<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence",
     "Id": "SEC101/101",
     "Name": "AadClientAppLegacyCredentials",
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence",
     "Pattern": "^[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{34}$",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/002",
     "Name": "Unclassified16ByteHexadecimalString",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^1234567890abcdef])[1234567890abcdef]{32}([^1234567890abcdef]|$)",
     "Signatures": null
   }

--- a/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
+++ b/GeneratedRegexPatterns/MediumConfidenceSecurityModels.json
@@ -1,17 +1,17 @@
 [
   {
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence",
     "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Signatures": [
       ".servicebus"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Id": "SEC101/528",
     "Name": "GenericJwt",
+    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Pattern": "(?:^|[^0-9A-Za-z-_.])e[0-9A-Za-z-_=]{23,}\\.e[0-9A-Za-z-_=]{23,}\\.[0-9A-Za-z-_=]{24,}(?:[^0-9A-Za-z-_]|$)",
     "Signatures": [
       "eyJ",
@@ -20,9 +20,9 @@
     ]
   },
   {
-    "DetectionMetadata": "MediumConfidence",
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
+    "DetectionMetadata": "MediumConfidence",
     "Pattern": "($|\\b)(ftps?|https?):\\/\\/(?P<refine>[^:@\\/]+:[^:@?\\/]+)@",
     "Signatures": [
       "ftp",
@@ -30,9 +30,9 @@
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Id": "SEC101/060",
     "Name": "LooseSasSecret",
+    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Pattern": "(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?P<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))",
     "Signatures": [
       "sig=",
@@ -40,9 +40,9 @@
     ]
   },
   {
-    "DetectionMetadata": "MediumConfidence",
     "Id": "SEC101/055",
     "Name": "Pkcs12CertificatePrivateKeyBundle",
+    "DetectionMetadata": "MediumConfidence",
     "Pattern": "MI[I-L][0-9a-zA-Z\\/+]{2}[AQgw]IBAzCC",
     "Signatures": [
       "IBAzCC"

--- a/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
+++ b/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
@@ -1,17 +1,17 @@
 [
   {
-    "DetectionMetadata": "Identifiable",
     "Id": "SEC101/200",
     "Name": "CommonAnnotatedSecurityKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{52}JQQJ9(?:9|D|H)[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890][A-L][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{16}[A-Za-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{7}(?:[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{2}==)?)",
     "Signatures": [
       "JQQJ"
     ]
   },
   {
-    "DetectionMetadata": "Identifiable",
     "Id": "SEC101/156",
     "Name": "AadClientAppIdentifiableCredentials",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/])(?P<refine>[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{3}(7|8)Q~[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{31,34})([^~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-+/]|$)",
     "Signatures": [
       "8Q~",
@@ -19,289 +19,180 @@
     ]
   },
   {
-    "ChecksumSeeds": [
-      5077085528363970608,
-      5575864757416767536,
-      6014965721085063216
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/158",
-    "KeyLength": 40,
     "Name": "AzureFunctionIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{44}AzFu[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]|$)",
     "Signatures": [
       "AzFu"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5869709231681187888
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/166",
-    "KeyLength": 39,
     "Name": "AzureSearchIdentifiableQueryKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzSe"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5783013817603469360
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": true,
     "Id": "SEC101/167",
-    "KeyLength": 39,
     "Name": "AzureSearchIdentifiableAdminKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{42}AzSe[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzSe"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/173",
-    "KeyLength": 32,
     "Name": "AzureRelayIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ARm[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ARm"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/172",
-    "KeyLength": 32,
     "Name": "AzureEventHubIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+AEh[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+AEh"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6009330654380044336,
-      5506058963192262704,
-      5575859178286952496
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/171",
-    "KeyLength": 32,
     "Name": "AzureServiceBusIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}\\+ASb[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ASb"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5291540757367369776
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/178",
-    "KeyLength": 32,
     "Name": "AzureIotHubIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928475562238095408
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/180",
-    "KeyLength": 32,
     "Name": "AzureIotDeviceIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4931568359632875568
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/179",
-    "KeyLength": 32,
     "Name": "AzureIotDeviceProvisioningIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AIoT[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AIoT"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928457935994778672
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/152",
-    "KeyLength": 64,
     "Name": "AzureStorageAccountIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ASt[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ASt"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5003045579370016816,
-      5575864757095706672,
-      5575864757096230960,
-      5937278606306848816,
-      6014965502159106096,
-      6014965720764330032,
-      6014965720764854320
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/160",
-    "KeyLength": 64,
     "Name": "AzureCosmosDBIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}ACDb[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "ACDb"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4711400055309086768
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/163",
-    "KeyLength": 64,
     "Name": "AzureBatchIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+ABa[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ABa"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4858365246511342384
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/170",
-    "KeyLength": 64,
     "Name": "AzureMLWebServiceClassicIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}\\+AMC[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+AMC"
     ]
   },
   {
-    "ChecksumSeeds": [
-      6081388236577714224
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/181",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableDirectManagementKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5291540757367369776
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/182",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableSubscriptionKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5143520228578766896
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/183",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableGatewayKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      5145771916421312560
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/184",
-    "KeyLength": 64,
     "Name": "AzureApimIdentifiableRepositoryKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{76}APIM[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}[AQgw]==)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "APIM"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4711718922539446320
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/154",
-    "KeyLength": 32,
     "Name": "AzureCacheForRedisIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AzCa[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AzCa"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4702692889634567216
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/176",
-    "KeyLength": 39,
     "Name": "AzureContainerRegistryIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{42}\\+ACR[A-D][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "+ACR"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/031",
     "Name": "NuGetApiKey",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(?i)(^|[^a-z0-9])(?P<refine>oy2[a-z2-7]{43})([^a-z0-9]|$)",
     "Signatures": [
       "oy2",
@@ -309,71 +200,66 @@
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, EmbeddedChecksum",
     "Id": "SEC101/102",
     "Name": "AdoLegacyPat",
+    "DetectionMetadata": "HighEntropy, EmbeddedChecksum",
     "Pattern": "(?:[^2-7a-z]|^)(?P<refine>[2-7a-z]{52})(?:[^2-7a-z]|$)",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy",
     "Id": "SEC101/104",
     "Name": "AzureCosmosDBLegacyCredentials",
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy",
     "Pattern": "(?i)\\.documents\\.azure\\.com.+(?:^|[^0-9a-z\\/+])(?P<refine>[0-9a-z\\/+]{86}==)(?:[^=]|$)",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy",
     "Id": "SEC101/106",
     "Name": "AzureStorageAccountLegacyCredentials",
+    "DetectionMetadata": "HighEntropy",
     "Pattern": "(?i)(?:AccountName|StorageName|StorageAccount)\\s*=.+(?:Account|Storage)Key\\s*=\\s*(?P<refine>[0-9a-z\\\\\\/+]{86}==)(?:[^=]|$)",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence",
     "Id": "SEC101/105",
     "Name": "AzureMessageLegacyCredentials",
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, MediumConfidence",
     "Pattern": "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)",
     "Signatures": [
       ".servicebus"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, HighConfidence",
     "Id": "SEC101/110",
     "Name": "AzureDatabricksPat",
+    "DetectionMetadata": "HighEntropy, HighConfidence",
     "Pattern": "(?:^|[^0-9a-f\\-])(?P<refine>dapi[0-9a-f\\-]{32,34})(?:[^0-9a-f\\-]|$)",
     "Signatures": [
       "dapi"
     ]
   },
   {
-    "ChecksumSeeds": [
-      4928457935994778672
-    ],
-    "DetectionMetadata": "Identifiable",
-    "EncodeForUrl": false,
     "Id": "SEC101/199",
-    "KeyLength": 32,
     "Name": "AzureEventGridIdentifiableKey",
+    "DetectionMetadata": "Identifiable",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])(?P<refine>[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{33}AZEG[A-P][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{5}=)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_=\\-]|$)",
     "Signatures": [
       "AZEG"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/050",
     "Name": "NpmAuthorKey",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>npm_[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]{36})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Signatures": [
       "npm_"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Id": "SEC101/565",
     "Name": "SecretScanningSampleToken",
+    "DetectionMetadata": "HighEntropy, FixedSignature, HighConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890])(?P<refine>secret_scanning_ab85fc6f8d7638cf1c11da812da308d43_[0-9A-Za-z]{5})([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890]|$)",
     "Signatures": [
       "ab85"

--- a/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
+++ b/GeneratedRegexPatterns/UnclassifiedPotentialSecurityKeys.json
@@ -1,8 +1,8 @@
 [
   {
-    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Id": "SEC101/528",
     "Name": "GenericJwt",
+    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Pattern": "(?:^|[^0-9A-Za-z-_.])e[0-9A-Za-z-_=]{23,}\\.e[0-9A-Za-z-_=]{23,}\\.[0-9A-Za-z-_=]{24,}(?:[^0-9A-Za-z-_]|$)",
     "Signatures": [
       "eyJ",
@@ -11,9 +11,9 @@
     ]
   },
   {
-    "DetectionMetadata": "MediumConfidence",
     "Id": "SEC101/127",
     "Name": "UrlCredentials",
+    "DetectionMetadata": "MediumConfidence",
     "Pattern": "($|\\b)(ftps?|https?):\\/\\/(?P<refine>[^:@\\/]+:[^:@?\\/]+)@",
     "Signatures": [
       "ftp",
@@ -21,9 +21,9 @@
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Id": "SEC101/060",
     "Name": "LooseSasSecret",
+    "DetectionMetadata": "HighEntropy, MediumConfidence",
     "Pattern": "(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?P<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))",
     "Signatures": [
       "sig=",
@@ -31,46 +31,46 @@
     ]
   },
   {
-    "DetectionMetadata": "LowConfidence",
     "Id": "SEC101/061",
     "Name": "OAuth2BearerToken",
+    "DetectionMetadata": "LowConfidence",
     "Pattern": "(?i)authorization:(\\s|%20)bearer(\\s|%20)(?P<refine>[0-9a-z][abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+\\/=]*)([^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_~.\\-+/=]|$)",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/000",
     "Name": "Unclassified32ByteBase64String",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{43}=",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/001",
     "Name": "Unclassified64ByteBase64String",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/_\\-])[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890+/]{86}==",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence",
     "Id": "SEC101/101",
     "Name": "AadClientAppLegacyCredentials",
+    "DetectionMetadata": "ObsoleteFormat, HighEntropy, LowConfidence",
     "Pattern": "^[~.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_\\-]{34}$",
     "Signatures": null
   },
   {
-    "DetectionMetadata": "MediumConfidence",
     "Id": "SEC101/055",
     "Name": "Pkcs12CertificatePrivateKeyBundle",
+    "DetectionMetadata": "MediumConfidence",
     "Pattern": "MI[I-L][0-9a-zA-Z\\/+]{2}[AQgw]IBAzCC",
     "Signatures": [
       "IBAzCC"
     ]
   },
   {
-    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Id": "SEC000/002",
     "Name": "Unclassified16ByteHexadecimalString",
+    "DetectionMetadata": "HighEntropy, Unclassified, LowConfidence",
     "Pattern": "(^|[^1234567890abcdef])[1234567890abcdef]{32}([^1234567890abcdef]|$)",
     "Signatures": null
   }

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -18,7 +18,8 @@
 - BRK: `RegexPattern.RotationPeriod` is no longer publicly settable.
 - BRK: `IdentifiableKey.RegexNormalizedSignature` is removed.
 - BRK: Abstract classes `IdentifiableKey`, `Azure32ByteIdentifiableKey`, `Azure64ByteIdentifiableKey`, and `AzureMessagingIdentifiableKey` now require derived classes to pass their signature to the base constructor.
-- NEW: Sort properties by name in GeneratedRegexPatterns/*.json.
+- BRK: Remove derived `RegexPattern` class properties `ChecksumSeeds`, `EncodeForUrl`, and `KeyLength` as these are not relevant to the literal authoring of equivalent regex patterns in other languages.
+- NEW: Provider deterministic ordering of properties in GeneratedRegexPatterns/*.json.
 - PRF: Remove unnecessary and expensive recomputation of `RegexPatter.Pattern`, `RegexPattern.Signatures`, and `IdentifiableKey.ChecksumSeeds` on every property access.
 
 # 1.16.0 - 03/05/2025

--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -18,8 +18,7 @@
 - BRK: `RegexPattern.RotationPeriod` is no longer publicly settable.
 - BRK: `IdentifiableKey.RegexNormalizedSignature` is removed.
 - BRK: Abstract classes `IdentifiableKey`, `Azure32ByteIdentifiableKey`, `Azure64ByteIdentifiableKey`, and `AzureMessagingIdentifiableKey` now require derived classes to pass their signature to the base constructor.
-- BRK: Remove derived `RegexPattern` class properties `ChecksumSeeds`, `EncodeForUrl`, and `KeyLength` as these are not relevant to the literal authoring of equivalent regex patterns in other languages.
-- NEW: Provider deterministic ordering of properties in GeneratedRegexPatterns/*.json.
+- NEW: Sort properties by name in GeneratedRegexPatterns/*.json.
 - PRF: Remove unnecessary and expensive recomputation of `RegexPatter.Pattern`, `RegexPattern.Signatures`, and `IdentifiableKey.ChecksumSeeds` on every property access.
 
 # 1.16.0 - 03/05/2025

--- a/src/Microsoft.Security.Utilities.Cli/ExportDetectionsCommand.cs
+++ b/src/Microsoft.Security.Utilities.Cli/ExportDetectionsCommand.cs
@@ -42,22 +42,11 @@ namespace Microsoft.Security.Utilities.Cli
             var settings = new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented,
-                ContractResolver = new OrderedContractResolver(),
                 Converters = { new StringEnumConverter() },
             };
 
             string json = JsonConvert.SerializeObject(patterns, settings);
             File.WriteAllText(outputFileName, json);
-        }
-
-        private sealed class OrderedContractResolver : DefaultContractResolver
-        {
-            protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
-            {
-                return base.CreateProperties(type, memberSerialization)
-                           .OrderBy(p => p.PropertyName, StringComparer.Ordinal)
-                           .ToList();
-            }
         }
     }
 }

--- a/src/Microsoft.Security.Utilities.Core/Base62.cs
+++ b/src/Microsoft.Security.Utilities.Core/Base62.cs
@@ -15,7 +15,7 @@ namespace Base62
     {
         [ThreadStatic]
         private static StringBuilder s_sb;
-        
+
         private const string DefaultCharacterSet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
         private const string InvertedCharacterSet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -118,30 +118,30 @@ namespace Base62
             switch (Type.GetTypeCode(typeof(T)))
             {
                 case TypeCode.String:
-                return (T)Convert.ChangeType(Encoding.UTF8.GetString(array), typeof(T), CultureInfo.InvariantCulture);
+                    return (T)Convert.ChangeType(Encoding.UTF8.GetString(array), typeof(T), CultureInfo.InvariantCulture);
                 case TypeCode.Int16:
-                if (BitConverter.IsLittleEndian)
-                {
-                    Array.Reverse(array);
-                }
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        Array.Reverse(array);
+                    }
 
-                return (T)Convert.ChangeType(BitConverter.ToInt16(array, 0), typeof(T), CultureInfo.InvariantCulture);
+                    return (T)Convert.ChangeType(BitConverter.ToInt16(array, 0), typeof(T), CultureInfo.InvariantCulture);
                 case TypeCode.Int32:
-                if (BitConverter.IsLittleEndian)
-                {
-                    Array.Reverse(array);
-                }
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        Array.Reverse(array);
+                    }
 
-                return (T)Convert.ChangeType(BitConverter.ToInt32(array, 0), typeof(T), CultureInfo.InvariantCulture);
+                    return (T)Convert.ChangeType(BitConverter.ToInt32(array, 0), typeof(T), CultureInfo.InvariantCulture);
                 case TypeCode.Int64:
-                if (BitConverter.IsLittleEndian)
-                {
-                    Array.Reverse(array);
-                }
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        Array.Reverse(array);
+                    }
 
-                return (T)Convert.ChangeType(BitConverter.ToInt64(array, 0), typeof(T), CultureInfo.InvariantCulture);
+                    return (T)Convert.ChangeType(BitConverter.ToInt64(array, 0), typeof(T), CultureInfo.InvariantCulture);
                 default:
-                throw new Exception($"Type of {typeof(T)} does not support.");
+                    throw new Exception($"Type of {typeof(T)} does not support.");
             }
         }
 

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableMetadata.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableMetadata.cs
@@ -426,7 +426,7 @@ internal static class IdentifiableMetadata
         catch (ArgumentOutOfRangeException) { return false; }
     }
 
-     private static bool AzureCacheForRedisWithSpecialCharacterChecksum(string secret, ulong checksumSeed)
+    private static bool AzureCacheForRedisWithSpecialCharacterChecksum(string secret, ulong checksumSeed)
     {
         byte[]? bytes = null;
 

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
@@ -28,7 +28,7 @@ public class IdentifiableScan : ISecretMasker
         this.orderedIds = new List<string>();
 
         var highPerformancePatterns = new HashSet<CompiledHighPerformancePattern>();
-        
+
         foreach (RegexPattern pattern in regexPatterns)
         {
             if (pattern.Signatures == null)

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableSecrets.cs
@@ -70,7 +70,7 @@ public static class IdentifiableSecrets
     public static bool TryValidateCommonAnnotatedKey(byte[] key,
                                                      string base64EncodedSignature)
     {
-        if (key == null || 
+        if (key == null ||
             (key.Length != StandardCommonAnnotatedKeySizeInBytes && key.Length != LongFormCommonAnnotatedKeySizeInBytes))
         {
             return false;
@@ -98,7 +98,7 @@ public static class IdentifiableSecrets
         int firstChecksumByteIndex = CommonAnnotatedKey.ChecksumBytesIndex;
         byte[] bytesToChecksum = new byte[firstChecksumByteIndex];
         Array.Copy(key, bytesToChecksum, bytesToChecksum.Length);
-        
+
         int checksum = Marvin.ComputeHash32(bytesToChecksum, checksumSeed, 0, bytesToChecksum.Length);
         byte[] computedChecksumBytes = BitConverter.GetBytes(checksum);
 
@@ -244,7 +244,7 @@ public static class IdentifiableSecrets
     }
 
     internal static string ComputeCommonAnnotatedHash(string textToHash,
-                                                    string commonAnnotatedSecret,                                                    
+                                                    string commonAnnotatedSecret,
                                                     bool longForm = false,
                                                     char hashedDataSignature = 'H')
     {
@@ -779,7 +779,7 @@ public static class IdentifiableSecrets
         int expectedChecksum = BitConverter.ToInt32(checksumBytes, 0);
         int actualChecksum = Marvin.ComputeHash32(bytes, checksumSeed, 0, bytes.Length - checksumSizeInBytes);
 
-        if (actualChecksum== expectedChecksum)
+        if (actualChecksum == expectedChecksum)
         {
             return true;
         }
@@ -942,20 +942,20 @@ public static class IdentifiableSecrets
         switch (padding)
         {
             case 2:
-            {
-                // Clear two bits where the signature will be right-shifted
-                // to align on the base64-encoded 6-bit boundary.
-                mask = 0xfcffffff;
-                break;
-            }
+                {
+                    // Clear two bits where the signature will be right-shifted
+                    // to align on the base64-encoded 6-bit boundary.
+                    mask = 0xfcffffff;
+                    break;
+                }
 
             case 4:
-            {
-                // Clear four bits where the signature will be right-shifted
-                // to remain aligned with base64-encoded 6-bit boundary.
-                mask = 0xf0ffffff;
-                break;
-            }
+                {
+                    // Clear four bits where the signature will be right-shifted
+                    // to remain aligned with base64-encoded 6-bit boundary.
+                    mask = 0xf0ffffff;
+                    break;
+                }
         }
 
         signature &= mask;

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
@@ -18,7 +18,7 @@ internal sealed class Unclassified32ByteBase64String : RegexPattern
         Id = "SEC000/000";
         Name = nameof(Unclassified32ByteBase64String);
         Pattern = $@"{WellKnownRegexPatterns.PrefixAllBase64}[{WellKnownRegexPatterns.Base64}]{{43}}=";
-        
+
         DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.Unclassified | DetectionMetadata.LowConfidence;
     }
 
@@ -31,7 +31,7 @@ internal sealed class Unclassified32ByteBase64String : RegexPattern
 
     public override IEnumerable<Detection> GetDetections(string input,
                                                          bool generateSha256Hashes,
-                                                         string defaultRedactionToken = RegexPattern.FallbackRedactionToken, 
+                                                         string defaultRedactionToken = RegexPattern.FallbackRedactionToken,
                                                          IRegexEngine? regexEngine = null)
     {
         foreach (Detection detection in base.GetDetections(input, generateSha256Hashes, defaultRedactionToken, regexEngine))

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_055_Pkcs12CertificatePrivateKeyBundle.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Security.Utilities
         // is would case the stress test (n=1000) to take 10+ minutes to run due the expensive nature of generating
         // private keys and certificates. We use Lazy here since during non-test execution we do not want to incur
         // the cost of generating these examples.
-        private static Lazy<List<string>> _truePositiveExamples = new Lazy<List<string>>(() => {
+        private static Lazy<List<string>> _truePositiveExamples = new Lazy<List<string>>(() =>
+        {
             var examples = new List<string>();
 #if NET6_0_OR_GREATER
             foreach (string? password in new string?[] { Guid.NewGuid().ToString(), null })

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_528_GenericJwt.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC101_528_GenericJwt.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Security.Utilities
                 header = $"{header}{Base64Padding(header)}";
                 decoded = Encoding.UTF8.GetString(Convert.FromBase64String(header));
             }
-            catch(FormatException)
+            catch (FormatException)
             {
                 return null;
             }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/IIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/IIdentifiableKey.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Security.Utilities
     {
         public string Id { get; }
 
-        public string Name { get; } 
-        
+        public string Name { get; }
+
         public uint KeyLength { get; }
-        
+
         public bool EncodeForUrl { get; }
 
         public ISet<string> Signatures { get; }

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_102_AdoPat.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Security.Utilities
     {
         private static readonly byte[] EmptyByteArray = new byte[0];
 
-        public AdoLegacyPat() 
+        public AdoLegacyPat()
         {
             Id = "SEC101/102";
             Name = nameof(AdoLegacyPat);

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_105_AzureMessagingLegacyCredentials.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Security.Utilities
         public AzureMessageLegacyCredentials()
         {
             Id = "SEC101/105";
-            Name = nameof(AzureMessageLegacyCredentials);         
+            Name = nameof(AzureMessageLegacyCredentials);
             DetectionMetadata = DetectionMetadata.HighEntropy | DetectionMetadata.ObsoleteFormat | DetectionMetadata.MediumConfidence;
             Pattern = "(?i)\\.servicebus\\.windows.+[^0-9a-z\\/+](?P<refine>[0-9a-z\\/+]{43}=)(?:[^=]|$)";
             Signatures = new HashSet<string>(new[] { ".servicebus" });

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_106_AzureStorageAccountLegacyCredentials.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Security.Utilities
     {
         private static readonly byte[] EmptyByteArray = new byte[0];
 
-        public AzureStorageAccountLegacyCredentials() 
+        public AzureStorageAccountLegacyCredentials()
         {
             Id = "SEC101/106";
             Name = nameof(AzureStorageAccountLegacyCredentials);

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_154_AzureCacheForRedisIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_154_AzureCacheForRedisIdentifiableKey.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Security.Utilities
         public override IEnumerable<string> GenerateTruePositiveExamples()
         {
             foreach (string key in base.GenerateTruePositiveExamples())
-            { 
+            {
                 if (key.Contains("/") || key.Contains("+"))
                 {
                     continue;

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_173_AzureRelayIdentifiableKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_173_AzureRelayIdentifiableKey.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Security.Utilities
 {
     public class AzureRelayIdentifiableKey : AzureMessagingIdentifiableKey
     {
-        public AzureRelayIdentifiableKey() :base(IdentifiableMetadata.AzureRelaySignature)
+        public AzureRelayIdentifiableKey() : base(IdentifiableMetadata.AzureRelaySignature)
         {
             Id = "SEC101/173";
             Name = nameof(AzureRelayIdentifiableKey);

--- a/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
+++ b/src/Microsoft.Security.Utilities.Core/PreciselyClassifiedSecurityKeys/SEC101_200_CommonAnnotatedSecurityKey.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Security.Utilities
             Name = nameof(CommonAnnotatedSecurityKey);
             DetectionMetadata = DetectionMetadata.Identifiable;
             Pattern = $"{WellKnownRegexPatterns.PrefixBase62}(?P<refine>[{WellKnownRegexPatterns.Base62}]{{52}}JQQJ9(?:9|D|H)[{WellKnownRegexPatterns.Base62}][A-L][{WellKnownRegexPatterns.Base62}]{{16}}[A-Za-z][{WellKnownRegexPatterns.Base62}]{{7}}(?:[{WellKnownRegexPatterns.Base62}]{{2}}==)?)";
-            Signatures =  Signature.ToSet(); 
+            Signatures = Signature.ToSet();
         }
 
 #if HIGH_PERFORMANCE_CODEGEN

--- a/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
+++ b/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
@@ -6,12 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Security.Utilities;
 
+[DataContract]
 public class RegexPattern
 {
     public const string FallbackRedactionToken = "+++";
@@ -33,11 +35,11 @@ public class RegexPattern
 
         Id = id;
         Name = name;
-        m_regexOptions = regexOptions;
-        Signatures = signatures;
-        RotationPeriod = rotationPeriod;
-        m_sampleGenerator = sampleGenerator;
         DetectionMetadata = patternMetadata;
+        RotationPeriod = rotationPeriod;
+        Signatures = signatures;
+        m_regexOptions = regexOptions;
+        m_sampleGenerator = sampleGenerator;
     }
 
 #pragma warning disable CS8618
@@ -304,6 +306,7 @@ public class RegexPattern
 
     public virtual Tuple<string, string>? GetMatchIdAndName(string match) => new Tuple<string, string>(Id, Name);
 
+    [DataMember(Order = 4)]
     public string Pattern { get; protected set; }
 
 #if NET7_0_OR_GREATER
@@ -315,13 +318,17 @@ public class RegexPattern
     /// <summary>
     /// Gets or sets an opaque, stable identifier for the pattern (corresponding to a SARIF 'reportingDescriptorReference.id' value).
     /// </summary>
+    [DataMember(Order = 1)]
+
     public string Id { get; protected set; }
 
     /// <summary>
     /// Gets or sets a readable name for the detection.
     /// </summary>
+    [DataMember(Order = 2)]
     public string Name { get; protected set; }
 
+    [DataMember(Order = 5)]
     public TimeSpan RotationPeriod { get; protected set; }
 
     /// <summary>
@@ -342,6 +349,7 @@ public class RegexPattern
     /// performance as these calls are typically much faster than
     /// equivalent regular expressions.
     /// </remarks>
+    [DataMember(Order = 6)]
     public ISet<string>? Signatures { get; protected set; }
 
     private readonly Func<string[]>? m_sampleGenerator;
@@ -352,6 +360,7 @@ public class RegexPattern
     /// </summary>
     /// <remarks>Options may not be available when .NET is not used to
     /// provide regex processing.</remarks>
+    [DataMember(Order = 3)]
     public DetectionMetadata DetectionMetadata { get; protected set; }
 
     public bool ShouldSerializeRotationPeriod() => false;

--- a/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
+++ b/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
@@ -319,7 +319,6 @@ public class RegexPattern
     /// Gets or sets an opaque, stable identifier for the pattern (corresponding to a SARIF 'reportingDescriptorReference.id' value).
     /// </summary>
     [DataMember(Order = 1)]
-
     public string Id { get; protected set; }
 
     /// <summary>

--- a/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
+++ b/src/Microsoft.Security.Utilities.Core/SecretMasker.cs
@@ -32,7 +32,7 @@ public class SecretMasker : ISecretMasker, IDisposable
         return new Version(version.Major, version.Minor, version.Build);
     }
 
-    public SecretMasker() : this (default, default, default, default, default)
+    public SecretMasker() : this(default, default, default, default, default)
     {
     }
 
@@ -424,7 +424,7 @@ public class SecretMasker : ISecretMasker, IDisposable
     public HashSet<SecretLiteral> EncodedSecretLiterals { get; }
     public HashSet<SecretLiteral> ExplicitlyAddedSecretLiterals { get; }
 
-    public ReaderWriterLockSlim SyncObject = new (LockRecursionPolicy.NoRecursion);
+    public ReaderWriterLockSlim SyncObject = new(LockRecursionPolicy.NoRecursion);
 
     private bool m_disposed;
 }


### PR DESCRIPTION
Previously, we simply alphabetized the Regex properties to make their order deterministic. This change preserves determinism by explicitly specifying `[DataMember(Order = X)]` (metadata that JSON.NET honors when serializing).

Now, we can consciously order the properties for readability while ensuring they remain in this constant order. I have accordingly moved the detections metadata information to follow the id and readable name (which in my opinion are most helpful to review early).

Finally, this change elides additional properties in derived types that are specific to scenarios such as identifiable secret detection. These additional properties are no universally applicable to regexes and in most cases relate to sample generation. It is not clear this metadata is useful to JSON file consumers due to the inconsistent and specialized nature of this data.