### PR TITLE
Flow all regex pattern properties from regex pattern to `IdentifiableScan` detection instances.

### DIFF
--- a/docs/ReleaseHistory.md
+++ b/docs/ReleaseHistory.md
@@ -18,6 +18,8 @@
 - BRK: `RegexPattern.RotationPeriod` is no longer publicly settable.
 - BRK: `IdentifiableKey.RegexNormalizedSignature` is removed.
 - BRK: Abstract classes `IdentifiableKey`, `Azure32ByteIdentifiableKey`, `Azure64ByteIdentifiableKey`, and `AzureMessagingIdentifiableKey` now require derived classes to pass their signature to the base constructor.
+- BUG: `IdentifiableScan` now properly flows `RegexPattern.RotationPeriod` to `Detection` instances. `Detection.RotationPeriod` previously always retained `default` as a value.
+- BUG: `IdentifiableScan` now properly flows `RegexPattern.DetectionMetadata` to `Detection` instances. `Detection.DetectionMetadata` was previously hard-coded as `DetectionMetadata.HighEntropy`.
 - NEW: Sort properties by name in GeneratedRegexPatterns/*.json.
 - PRF: Remove unnecessary and expensive recomputation of `RegexPatter.Pattern`, `RegexPattern.Signatures`, and `IdentifiableKey.ChecksumSeeds` on every property access.
 

--- a/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
+++ b/src/Microsoft.Security.Utilities.Core/IdentifiableScan.cs
@@ -120,9 +120,10 @@ public class IdentifiableScan : ISecretMasker
             Name = result.Item2,
             Start = detection.Start,
             Length = detection.Length,
-            Metadata = DetectionMetadata.HighEntropy,
-            CrossCompanyCorrelatingId = c3id,
             RedactionToken = redactionToken,
+            CrossCompanyCorrelatingId = c3id,
+            Metadata = pattern.DetectionMetadata,
+            RotationPeriod = pattern.RotationPeriod,
         };
     }
 

--- a/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/IdentifiableScanTests.cs
@@ -22,8 +22,9 @@ namespace Tests.Microsoft.Security.Utilities.Core
             var cask = new CommonAnnotatedSecurityKey();
             var examples = cask.GenerateTruePositiveExamples().ToList();
 
-            var masker = new IdentifiableScan(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
-                                              generateCorrelatingIds: false);
+            using var masker =
+                new IdentifiableScan(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
+                                     generateCorrelatingIds: false);
 
             foreach (string example in examples)
             {
@@ -51,7 +52,7 @@ namespace Tests.Microsoft.Security.Utilities.Core
 
             using var assertionScope = new AssertionScope();
 
-            var masker = new IdentifiableScan(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
+            using var masker = new IdentifiableScan(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
                                               generateCorrelatingIds: false);
 
             foreach (var pattern in WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys)
@@ -83,6 +84,34 @@ namespace Tests.Microsoft.Security.Utilities.Core
                             found.Should().Be(1, because: $"{moniker} should match against '{key}' a single time, not {found} time(s)");
                         }
                     }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IdentifiableScan_BehaviorMatchesStandardScanner()
+        {
+            using var assertionScope = new AssertionScope();
+
+            using var standardMasker =
+                new SecretMasker(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
+                                 generateCorrelatingIds: false);
+
+            using var highPerformanceMasker =
+                new IdentifiableScan(WellKnownRegexPatterns.HighConfidenceMicrosoftSecurityModels,
+                                     generateCorrelatingIds: false);
+
+            foreach (var pattern in WellKnownRegexPatterns.PreciselyClassifiedSecurityKeys)
+            {
+                foreach (string example in pattern.GenerateTruePositiveExamples())
+                {
+                    var standardDetections = standardMasker.DetectSecrets(example).ToList();
+
+                    var highPerformanceDetections = highPerformanceMasker.DetectSecrets(example).ToList();
+
+                    highPerformanceDetections.Should().BeEquivalentTo(standardDetections,
+                        options => options.WithStrictOrdering(),
+                        because: $"the high-performance scanner should match the standard scanner for '{example}'");
                 }
             }
         }


### PR DESCRIPTION
- BUG: `IdentifiableScan` now properly flows `RegexPattern.RotationPeriod` to `Detection` instances. `Detection.RotationPeriod` previously always retained `default` as a value.
- BUG: `IdentifiableScan` now properly flows `RegexPattern.DetectionMetadata` to `Detection` instances. `Detection.DetectionMetadata` was previously hard-coded as `DetectionMetadata.HighEntropy`.
