### PR TITLE
Exclude test global packages folder from msbuild item globbing

### DIFF
--- a/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/Nuget.config
+++ b/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/Nuget.config
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<config>
-		<add key="globalPackagesFolder" value="globalPackagesFolderTest" />
+		<!---
+			WARNING: Keep this in folder in a location that is excluded from default
+			item globbing (like under obj) or msbuild will slow down drastically,
+			resolve references to random incompatible dlls in this folder, and break
+			the build in the strangest of ways. This can also be fixed in the project
+			file by removing CandidateAssemblyFiles from AssemblySearchPaths or
+			setting EnableDefaultNoneItems to false, or both. However, we should not
+			put workarounds into the project file as it's meant to be a test of what a
+			normal customer project file would look like.
+		-->
+		<add key="globalPackagesFolder" value="obj\packages" />
 	</config>
 	<fallbackPackageFolders>
 		<add key="LocalBuild" value="..\..\..\bld\nupkg\AnyCPU_Release\" />


### PR DESCRIPTION
MSBuild is finding random dlls in globalPackagesFolderForTest and resolving references to them outside of NuGet's rules.

The fix is to put this folder into obj\ where it will be ignored by item globbing. The same issue was encountered in an internal project and the same fix was used.

I am not sure why this hasn't broken the build sooner or why it started breaking the build on my machine now, but hasn't impacted CI, but regardless, we really should not be allowing globalPackagesFolderForTest to participate in globbing.