### PR TITLE
WIP: Remove relationship between correlating IDs and redaction tokens.

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/Detection.cs
+++ b/src/Microsoft.Security.Utilities.Core/Detection.cs
@@ -16,18 +16,18 @@ public sealed class Detection
                      string? label,
                      int start,
                      int length,
+                     DetectionKind kind,
                      DetectionMetadata metadata,
                      TimeSpan rotationPeriod = default,
-                     string? crossCompanyCorrelatingId = null,
-                     string? redactionToken = null)
+                     string? crossCompanyCorrelatingId = null)
     {
         Id = id;
         Name = name;
         Label = label;
         Start = start;
         Length = length;
+        Kind = kind;
         Metadata = metadata;
-        RedactionToken = redactionToken;
         RotationPeriod = rotationPeriod;
         CrossCompanyCorrelatingId = crossCompanyCorrelatingId;
     }
@@ -57,18 +57,18 @@ public sealed class Detection
 
     public int End => Start + Length;
 
+    public DetectionKind Kind { get; }
+
     public DetectionMetadata Metadata { get; }
 
     public TimeSpan RotationPeriod { get; }
 
     public string? CrossCompanyCorrelatingId { get; }
 
-    public string? RedactionToken { get; }
-
 #if DEBUG
     public override string ToString()
     {
-        return $"{Id}.{Name}:{Start}-{Start + Length}:{Metadata}:{CrossCompanyCorrelatingId}:{RedactionToken}";
+        return $"{Id}.{Name}:{Start}-{Start + Length}:{Kind}:{Metadata}:{CrossCompanyCorrelatingId}";
     }
 #endif
 }

--- a/src/Microsoft.Security.Utilities.Core/DetectionKind.cs
+++ b/src/Microsoft.Security.Utilities.Core/DetectionKind.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Security.Utilities;
+
+[Flags]
+public enum DetectionKind
+{
+    // NOTE: The order here impacts which redaction token will be preferred when
+    //       there are adjacent or overlapping redactions merged into a single
+    //       token. Smaller values have priority over higher values so that
+    //       literal redaction takes precedence over regex redaction.
+
+    /// <summary>
+    /// The detection was made using a literal value supplied to <see cref="SecretMasker.AddValue"/>.
+    /// </summary>
+    Literal = 0,
+
+    /// <summary>
+    /// The detection was made using a <see cref="RegexPattern"/>
+    /// </summary>
+    RegexPattern = 1,
+}

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_000_Unclassified32ByteBase64String.cs
@@ -32,19 +32,17 @@ internal sealed class Unclassified32ByteBase64String : RegexPattern
     }
 
     public override IEnumerable<Detection> GetDetections(string input,
-                                                         bool generateSha256Hashes,
-                                                         string defaultRedactionToken = RegexPattern.FallbackRedactionToken,
+                                                         bool generateCrossCompanyCorrelatingIds,
                                                          IRegexEngine? regexEngine = null)
     {
-        foreach (Detection detection in base.GetDetections(input, generateSha256Hashes, defaultRedactionToken, regexEngine))
+        foreach (Detection detection in base.GetDetections(input, generateCrossCompanyCorrelatingIds, regexEngine))
         {
             string match = input.Substring(detection.Start, detection.Length);
 
 
-            if (!object.Equals(azure32ByteIdentifiableKeys.GetDetections(match,
-                                                                         generateSha256Hashes,
-                                                                         defaultRedactionToken,
-                                                                         regexEngine).FirstOrDefault(), objB: default))
+            if (azure32ByteIdentifiableKeys.GetDetections(match,
+                                                          generateCrossCompanyCorrelatingIds: false,
+                                                          regexEngine).Any())
             {
                 continue;
             }

--- a/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
+++ b/src/Microsoft.Security.Utilities.Core/PotentialSecurityKeys/SEC000_001_Unclassified64ByteBase64String.cs
@@ -33,18 +33,16 @@ internal sealed class Unclassified64ByteBase64String : RegexPattern
     }
 
     public override IEnumerable<Detection> GetDetections(string input,
-                                                         bool generateSha256Hashes,
-                                                         string defaultRedactionToken = RegexPattern.FallbackRedactionToken,
+                                                         bool generateCrossCompanyCorrelatingIds,
                                                          IRegexEngine? regexEngine = null)
     {
-        foreach (Detection detection in base.GetDetections(input, generateSha256Hashes, defaultRedactionToken, regexEngine))
+        foreach (Detection detection in base.GetDetections(input, generateCrossCompanyCorrelatingIds, regexEngine))
         {
             string match = input.Substring(detection.Start, detection.Length);
 
-            if (!Equals(azure64ByteIdentifiableKeys.GetDetections(match,
-                                                                         generateSha256Hashes,
-                                                                         defaultRedactionToken,
-                                                                         regexEngine).FirstOrDefault(), objB: default))
+            if (azure64ByteIdentifiableKeys.GetDetections(match,
+                                                          generateCrossCompanyCorrelatingIds: false,
+                                                          regexEngine).Any())
             {
                 continue;
             }

--- a/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
+++ b/src/Microsoft.Security.Utilities.Core/RegexPattern.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Security.Utilities;
 [DataContract]
 public class RegexPattern
 {
-    public const string FallbackRedactionToken = "+++";
-
     /// <summary>Constructs a new instance of the RegexPattern class.</summary>
     /// <param name="id"> The unique identifier for the pattern.</param>
     /// <param name="name">The name of the pattern.</param>
@@ -186,7 +184,6 @@ public class RegexPattern
 
     public virtual IEnumerable<Detection> GetDetections(string input,
                                                         bool generateCrossCompanyCorrelatingIds,
-                                                        string defaultRedactionToken = FallbackRedactionToken,
                                                         IRegexEngine? regexEngine = null)
     {
         if (input == null)
@@ -222,18 +219,6 @@ public class RegexPattern
                         ? GenerateCrossCompanyCorrelatingId(match.Value)
                         : null;
 
-                string? redactionToken = crossCompanyCorrelatingId != null
-                        ? $"{Id}:{crossCompanyCorrelatingId}"
-                        : defaultRedactionToken;
-
-                // If the user has provided a null or empty redaction
-                // token, we will use the fallback so that redaction
-                // is clearly evident in the output.
-                if (string.IsNullOrWhiteSpace(redactionToken))
-                {
-                    redactionToken = FallbackRedactionToken;
-                }
-
                 Tuple<string, string>? moniker = GetMatchIdAndName(match.Value);
                 if (moniker == default)
                 {
@@ -248,12 +233,11 @@ public class RegexPattern
                                            label: Label,
                                            match.Index,
                                            match.Length,
+                                           DetectionKind.RegexPattern,
                                            DetectionMetadata,
                                            RotationPeriod,
-                                           crossCompanyCorrelatingId,
-                                           redactionToken);
+                                           crossCompanyCorrelatingId);
             }
-
         }
     }
 

--- a/src/Microsoft.Security.Utilities.Core/SecretLiteral.cs
+++ b/src/Microsoft.Security.Utilities.Core/SecretLiteral.cs
@@ -8,34 +8,17 @@ using System.Collections.Generic;
 
 namespace Microsoft.Security.Utilities;
 
-public class SecretLiteral
+internal record struct SecretLiteral
 {
-    public const string FallbackRedactionToken = "***";
+    public string Value { get; }
 
     public SecretLiteral(string value)
     {
         Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
-    public override bool Equals(object? obj)
+    public IEnumerable<Detection> GetDetections(string input)
     {
-        var item = obj as SecretLiteral;
-        if (item == null)
-        {
-            return false;
-        }
-        return string.Equals(Value, item.Value, StringComparison.Ordinal);
-    }
-
-    public override int GetHashCode() => Value.GetHashCode();
-
-    public IEnumerable<Detection> GetDetections(string input, string redactionToken)
-    {
-        if (string.IsNullOrWhiteSpace(redactionToken))
-        {
-            redactionToken = FallbackRedactionToken;
-        }
-
         if (!string.IsNullOrEmpty(input) && !string.IsNullOrEmpty(Value))
         {
             int startIndex = 0;
@@ -51,15 +34,12 @@ public class SecretLiteral
                                                label: null,
                                                start: startIndex,
                                                length: Value.Length,
-                                               metadata: 0,
-                                               rotationPeriod: default,
-                                               crossCompanyCorrelatingId: null,
-                                               redactionToken);
+                                               DetectionKind.Literal,
+                                               DetectionMetadata.None,
+                                               rotationPeriod: default);
                     ++startIndex;
                 }
             }
         }
     }
-
-    public string Value { get; private set; }
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/DetectionTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/DetectionTests.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection.Emit;
 
 namespace Tests.Microsoft.Security.Utilities
 {
@@ -23,6 +22,7 @@ namespace Tests.Microsoft.Security.Utilities
             string redactionToken = $"{Guid.NewGuid()}";
 
             var metadata = (DetectionMetadata)0B_11111;
+            var kind = (DetectionKind)42;
             int start = Math.Max(1, (int)DateTime.UtcNow.Ticks % 99);
             int length = Math.Max(1, (int)DateTime.UtcNow.Ticks % 99);
             var rotationPeriod = TimeSpan.FromSeconds(Math.Max(1, DateTime.UtcNow.Second));
@@ -32,10 +32,10 @@ namespace Tests.Microsoft.Security.Utilities
                                           label,
                                           start,
                                           length,
+                                          kind,
                                           metadata,
                                           rotationPeriod,
-                                          crossCompanyCorrelatingId,
-                                          redactionToken);
+                                          crossCompanyCorrelatingId);
 
             Assert.AreEqual(id, detection.Id);
             Assert.AreEqual(name, detection.Name);
@@ -43,9 +43,9 @@ namespace Tests.Microsoft.Security.Utilities
             Assert.AreEqual(start, detection.Start);
             Assert.AreEqual(length, detection.Length);
             Assert.AreEqual(metadata, detection.Metadata);
+            Assert.AreEqual(kind, detection.Kind);
             Assert.AreEqual(start + length, detection.End);
             Assert.AreEqual(rotationPeriod, detection.RotationPeriod);
-            Assert.AreEqual(redactionToken, detection.RedactionToken);
             Assert.AreEqual(crossCompanyCorrelatingId, detection.CrossCompanyCorrelatingId);
 
             detection = new Detection(string.Empty,
@@ -54,8 +54,8 @@ namespace Tests.Microsoft.Security.Utilities
                                       int.MinValue,
                                       int.MaxValue,
                                       0,
-                                      rotationPeriod: default,
-                                      string.Empty);
+                                      0,
+                                      rotationPeriod: default);
 
             Assert.AreNotEqual(id, detection.Id);
             Assert.AreNotEqual(name, detection.Name);
@@ -66,7 +66,6 @@ namespace Tests.Microsoft.Security.Utilities
             Assert.AreNotEqual(start + length, detection.End);
             Assert.AreNotEqual(rotationPeriod, detection.CrossCompanyCorrelatingId);
             Assert.AreNotEqual(rotationPeriod, detection.RotationPeriod);
-            Assert.AreNotEqual(redactionToken, detection.RedactionToken);
         }
     }
 }

--- a/src/Tests.Microsoft.Security.Utilities.Core/RegexPatternTests.cs
+++ b/src/Tests.Microsoft.Security.Utilities.Core/RegexPatternTests.cs
@@ -413,11 +413,10 @@ public class RegexPatternTests
         // It is critical that our hashing is consistent across the library's .NET FX
         // and .NET 5.0 versions, so we hard-code this test to ensure things are in sync.
         Assert.AreEqual($"rPHgxCVAOw6CZsT9xXEw", replacement.CrossCompanyCorrelatingId);
-        Assert.AreEqual($"{Id}:rPHgxCVAOw6CZsT9xXEw", replacement.RedactionToken);
     }
 
     [TestMethod]
-    public void RegexPatterns_GetDetections_ReturnsEmpty_WhenNoMatchesExist()
+    public void RegexPattern_GetDetections_ReturnsEmpty_WhenNoMatchesExist()
     {
         // Arrange
         var secret = new RegexPattern(Id, Name, Label, DetectionMetadata.Identifiable, "abc");
@@ -431,7 +430,7 @@ public class RegexPatternTests
     }
 
     [TestMethod]
-    public void RegexPatterns_GetDetections_Returns_RefinedDetection()
+    public void RegexPattern_GetDetections_ReturnsRefinedDetection()
     {
         // Arrange
         var secret = new RegexPattern(Id, Name, Label, DetectionMetadata.Identifiable, "a(?P<refine>b)c");
@@ -445,27 +444,27 @@ public class RegexPatternTests
 
         // Assert
         Assert.AreEqual(1, actual: detections.Count());
-
         Assert.AreEqual(match, actual: input.Substring(detection.Start, detection.Length));
-        Assert.AreEqual(redactionToken, actual: detection.RedactionToken);
     }
 
     [TestMethod]
-    public void RegexPatterns_GetDetections_Returns_SecureTelemetryTokenValue_WhenMonikerSpecified()
+    public void RegexPatterns_GetDetections_ReturnsMonikerAndCrossCompanyCorrelatingId()
     {
         // Arrange
         string ruleMoniker = $"{Id}.{Name}";
         var secret = new RegexPattern(Id, Name, Label, DetectionMetadata.Identifiable, "abc");
         string input = "abc";
 
-        string redactionToken = $"{Id}:{RegexPattern.GenerateCrossCompanyCorrelatingId(input)}";
+        string correlatingId = RegexPattern.GenerateCrossCompanyCorrelatingId(input);
 
         // Act
         IEnumerable<Detection> replacements = secret.GetDetections(input, generateCrossCompanyCorrelatingIds: true);
 
         // Assert
         Assert.AreEqual(1, actual: replacements.Count());
-        Assert.AreEqual(redactionToken, actual: replacements.First().RedactionToken);
+        Detection detection = replacements.Single();
+        Assert.AreEqual(ruleMoniker, detection.Moniker);
+        Assert.AreEqual(correlatingId, detection.CrossCompanyCorrelatingId);
     }
 
     [TestMethod]


### PR DESCRIPTION
Quick draft to help ongoing discussion. It is not clear yet if we want this change, but sketching it out.

With this change, it would no longer be the case that detections with C3IDs would get a custom redaction token. To report the C3ID somewhere, one would have to use the data returned via `Detection.CorrelatingId`.

A less aggressive, more compatible, but also more complex change would allow to opt-in/out to/from C3IDs in redaction tokens. I think this change is preferable unless we are sure there's a real use case for the C3IDs in redaction tokens.