### PR TITLE
Use actual namespace as RootNamespace

### DIFF
--- a/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
+++ b/src/Microsoft.Security.Utilities.Core/Microsoft.Security.Utilities.Core.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RootNamespace>Microsoft.Security.Utilities.Core</RootNamespace>
+    <RootNamespace>Microsoft.Security.Utilities</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
This is breaking the build if you let VS regenerate the strongly-typed resource code in #218.

The namespace does not actually have Core in it.