### PR TITLE
Remove msvc_spectre_libs dependency to increase build target compatibility

### DIFF
--- a/src/security_utilities_rust/Cargo.toml
+++ b/src/security_utilities_rust/Cargo.toml
@@ -17,9 +17,6 @@ sha2 = "0.10.8"
 substring = "1.4.5"
 uuid = { version = "1.8.0", features = ["v4"] }
 
-# Causes the project to link with the Spectre-mitigated CRT and libs.
-msvc_spectre_libs = { version = "0.1", features = ["error"] }
-
 [dev-dependencies]
 criterion = "0.5.1"
 


### PR DESCRIPTION
Proposing a fix for https://github.com/microsoft/security-utilities/issues/232

As a generic library `security_utilities_rust` should not reference the msvc_spectre_libs cargo - it is the final consuming Rust project, like a Windows EXE or DLL project's responsibility to decide whether or not to link against the Spectre mitigated MSVC libs.

The fix removes the msvc_spectre_libs reference.