### PR TITLE
Fix build issues

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Build">
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13</LangVersion>
     <OutputSubDir>$(Platform)_$(Configuration)</OutputSubDir>
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(OutputSubDir)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>

--- a/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/Nuget.config
+++ b/src/SecurityUtilitiesPackageReference/SecurityUtilitiesApiUtilizationExample/Nuget.config
@@ -17,17 +17,12 @@
 		<add key="LocalBuild" value="..\..\..\bld\nupkg\AnyCPU_Release\" />
 	</fallbackPackageFolders>
 	<packageSources>
-		<clear />
 		<add key="LocalBuild" value="..\..\..\bld\nupkg\AnyCPU_Release\" />
-		<add key="PublicNugetOrg" value="https://api.nuget.org/v3/index.json" />
 	</packageSources>
 	<packageSourceMapping>
 		<packageSource key="LocalBuild">
 			<package pattern="Microsoft.Security.Utilities.*" />
 			<package pattern="Sarif.*" />
-		</packageSource>
-		<packageSource key="PublicNugetOrg">
-			<package pattern="*" />
 		</packageSource>
 	</packageSourceMapping>
 </configuration>


### PR DESCRIPTION
1. Using LangVersion=14 with .NET SDK 10.x while targeting .NET 10.0 hits a breaking change with Enumerable.Reverse vs Span.Reverse.

See https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/breaking-changes/compiler%20breaking%20changes%20-%20dotnet%2010#enumerablereverse

Fix: Lower LangVersion to 13.

2. The NuGet.config for the SecurityUtilitiesApiUtilizationExample was incompatible with a wrapping environment that disallows public NuGet.org feed.

Fix: Stop clearing feeds and stop referencing NuGet.org there.